### PR TITLE
POST parameters

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -162,6 +162,15 @@
                   (assoc :request-method m)))
       (client req))))
 
+(defn wrap-form-params [client]
+  (fn [{:keys (form-params) :as req}]
+    (if form-params
+      (client (-> req
+                  (dissoc :form-params)
+                  (assoc :content-type (content-type-value :x-www-form-urlencoded)
+                          :body (generate-query-string form-params))))
+      (client req))))
+
 (defn wrap-url [client]
   (fn [req]
     (if-let [url (:url req)]
@@ -185,6 +194,7 @@
       wrap-accept
       wrap-accept-encoding
       wrap-content-type
+      wrap-form-params
       wrap-method
       wrap-cookies))
 

--- a/test/clj_http/client_test.clj
+++ b/test/clj_http/client_test.clj
@@ -194,7 +194,6 @@
     (is (= :val (:key echo)))
     (is (not (:request-method echo)))))
 
-
 (deftest apply-on-url
   (let [u-client (client/wrap-url identity)
         resp (u-client {:url "http://google.com:8080/foo?bar=bat"})]
@@ -214,3 +213,18 @@
   (is (= 8080 (-> "http://example.com:8080/" client/parse-url :server-port)))
   (is (= 443  (-> "https://example.com/" client/parse-url :server-port)))
   (is (= 8443 (-> "https://example.com:8443/" client/parse-url :server-port))))
+
+(deftest apply-on-form-params
+  (testing "With form params"
+    (let [param-client (client/wrap-form-params identity)
+          resp (param-client {:form-params {:param1 "value1"
+                                            :param2 "value2"}})]
+      (is (= "param1=value1&param2=value2" (:body resp)))
+      (is (= "application/x-www-form-urlencoded" (:content-type resp)))
+      (is (not (contains? resp :form-params)))))
+  
+  (testing "with no form params"
+    (let [param-client (client/wrap-form-params identity)
+          resp (param-client {:body "untouched"})]
+      (is (= "untouched" (:body resp)))
+      (is (not (contains? resp :content-type))))))


### PR DESCRIPTION
This change was originally submitted to the original clj-http project.  Sending the pull request here since this is the new fork.  It just a new middleware that takes a parameter map and converts it to a properly encoded form to be POSTed.
