### PR TITLE
Compression headers not being set

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -57,7 +57,7 @@
     (if (get-in req [:headers "Accept-Encoding"])
       (client req)
       (let [req-c (update req :headers assoc "Accept-Encoding" "gzip, deflate")
-            resp-c (client req)]
+            resp-c (client req-c)]
         (case (get-in resp-c [:headers "Content-Encoding"])
           "gzip"
           (update resp-c :body util/gunzip)

--- a/test/clj_http/client_test.clj
+++ b/test/clj_http/client_test.clj
@@ -83,15 +83,19 @@
 
 
 (deftest apply-on-compressed
-  (let [client (fn [req] {:body (util/gzip (util/utf8-bytes "foofoofoo"))
-                          :headers {"Content-Encoding" "gzip"}})
+  (let [client (fn [req]
+                 (is (= "gzip, deflate" (get-in req [:headers "Accept-Encoding"])))
+                 {:body (util/gzip (util/utf8-bytes "foofoofoo"))
+                  :headers {"Content-Encoding" "gzip"}})
         c-client (client/wrap-decompression client)
         resp (c-client {})]
     (is (= "foofoofoo" (util/utf8-string (:body resp))))))
 
 (deftest apply-on-deflated
-  (let [client (fn [req] {:body (util/deflate (util/utf8-bytes "barbarbar"))
-                          :headers {"Content-Encoding" "deflate"}})
+  (let [client (fn [req]
+                 (is (= "gzip, deflate" (get-in req [:headers "Accept-Encoding"])))
+                 {:body (util/deflate (util/utf8-bytes "barbarbar"))
+                  :headers {"Content-Encoding" "deflate"}})
         c-client (client/wrap-decompression client)
         resp (c-client {})]
     (is (= "barbarbar" (util/utf8-string (:body resp))))))


### PR DESCRIPTION
Fixed a bug where the Accept-Encoding header wasn't being set for compressed streams
