### PR TITLE
POST Parameters with request method check

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -165,8 +165,8 @@
       (client req))))
 
 (defn wrap-form-params [client]
-  (fn [{:keys (form-params) :as req}]
-    (if form-params
+  (fn [{:keys (form-params request-method) :as req}]
+    (if (and form-params (= :post request-method))
       (client (-> req
                   (dissoc :form-params)
                   (assoc :content-type (content-type-value :x-www-form-urlencoded)

--- a/test/clj_http/client_test.clj
+++ b/test/clj_http/client_test.clj
@@ -227,11 +227,20 @@
 (deftest apply-on-form-params
   (testing "With form params"
     (let [param-client (client/wrap-form-params identity)
-          resp (param-client {:form-params {:param1 "value1"
+          resp (param-client {:request-method :post
+                              :form-params {:param1 "value1"
                                             :param2 "value2"}})]
       (is (= "param1=value1&param2=value2" (:body resp)))
       (is (= "application/x-www-form-urlencoded" (:content-type resp)))
       (is (not (contains? resp :form-params)))))
+  (testing "Ensure it does not affect GET requests"
+    (let [param-client (client/wrap-form-params identity)
+          resp (param-client {:request-method :get
+                              :body "untouched"
+                              :form-params {:param1 "value1"
+                                            :param2 "value2"}})]
+      (is (= "untouched" (:body resp)))
+      (is (not (contains? resp :content-type)))))
   
   (testing "with no form params"
     (let [param-client (client/wrap-form-params identity)


### PR DESCRIPTION
Based on feedback from my last pull request, I've added POST parameter support with a guard so that it only uses it on a POST request.
