### PR TITLE
Missing require

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -1,5 +1,6 @@
 (ns clj-http.core
   "Core HTTP request/response implementation."
+  (:require [clojure.pprint])
   (:import (java.net URI)
            (org.apache.http HttpRequest HttpEntityEnclosingRequest
                             HttpResponse Header HttpHost)


### PR DESCRIPTION
Hi,

When trying to AOT compile my application that uses clj-http, it was complaining that it couldn't find clojure.pprint. I added a (:require) and the error went away.

So just a one line change, pls pull if you think it's an error.
- Steve
