### PR TITLE
improved message when clj-http calls throw+

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -34,7 +34,7 @@
       (if (or (not (clojure.core/get req :throw-exceptions true))
               (unexceptional-status? status))
         resp
-        (throw+ resp)))))
+        (throw+ resp "clj-http: status %s" (:status %))))))
 
 (declare wrap-redirects)
 


### PR DESCRIPTION
This takes advantage of a recent slingshot feature that can provide customized messages on the exception (Stone) that's thrown. "Object thrown by throw+" is now only a default. Please consider adopting this message which I think improves clarity and brevity.
