### PR TITLE
change to core/parse-headers to handle multiple headers with the same name

### DIFF
--- a/test/clj_http/core_test.clj
+++ b/test/clj_http/core_test.clj
@@ -156,3 +156,28 @@
             :server-name "localhost"
             :server-port 18080}
            (dissoc (:request resp) :body)))))
+
+(deftest parse-headers
+  (are [headers expected]
+       (let [iterator (BasicHeaderIterator. (into-array BasicHeader
+                                                        (map (fn [[name value]] (BasicHeader. name value))
+                                                             headers))
+                                            nil)]
+         (is (= (core/parse-headers iterator)
+                expected)))
+
+       []
+       {}
+
+       [["Set-Cookie" "one"]]
+       {"set-cookie" "one"}
+
+       [["Set-Cookie" "one"]
+        ["set-COOKIE" "two"]]
+       {"set-cookie" ["one" "two"]}
+
+       [["Set-Cookie" "one"]
+        ["serVer"     "some-server"]
+        ["set-cookie" "two"]]
+       {"set-cookie" ["one" "two"]
+        "server"     "some-server"}))


### PR DESCRIPTION
I was using clj-http to download some web pages, some of which required logging in, which in turn dropped a number of cookies.  I noticed that only the last cookie was ever kept and found the problem in parse-headers.

From inspecting the code it appears that `wrap-cookie` is expecting the set-cookie header to be either a string or a seq of strings.  I changed parse-headers so that when multiple headers with the same name are found that they are collected into a vector, otherwise just the single string value is returned.

I've added a test to test-core too.
