### PR TITLE
Avoid reflection by adding type hints

### DIFF
--- a/src/clj_http/cookies.clj
+++ b/src/clj_http/cookies.clj
@@ -8,7 +8,7 @@
            (org.apache.http.impl.cookie BrowserCompatSpecFactory)
            (org.apache.http.message BasicHeader)))
 
-(defn- cookie-spec []
+(defn- cookie-spec ^org.apache.http.cookie.CookieSpec []
   (.newInstance
    (BrowserCompatSpecFactory.)
    (doto (BasicHttpParams.)
@@ -93,7 +93,7 @@
   (when-let [header (-> (cookie-spec)
                         (.formatCookies [(to-basic-client-cookie cookie)])
                         first)]
-    (.getValue header)))
+    (.getValue ^org.apache.http.Header header)))
 
 (defn encode-cookies
   "Encode the cookie map into a string."

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -56,7 +56,7 @@
     (.setURI res (URI. url))
     res))
 
-(def insecure-socket-factory
+(def ^SSLSocketFactory insecure-socket-factory
   (doto (SSLSocketFactory. (reify TrustStrategy
                              (isTrusted [_ _ _] true)))
     (.setHostnameVerifier SSLSocketFactory/ALLOW_ALL_HOSTNAME_VERIFIER)))
@@ -117,9 +117,9 @@
                       CookiePolicy/BROWSER_COMPATIBILITY)
     (set-client-param ClientPNames/HANDLE_REDIRECTS false)
     (set-client-param "http.socket.timeout"
-                      (and socket-timeout (Integer. socket-timeout)))
+                      (and socket-timeout (Integer. ^Long socket-timeout)))
     (set-client-param "http.connection.timeout"
-                      (and conn-timeout (Integer. conn-timeout))))
+                      (and conn-timeout (Integer. ^Long conn-timeout))))
   (when (nil? (#{"localhost" "127.0.0.1"} server-name))
     (when-let [proxy-host (System/getProperty (str scheme ".proxyHost"))]
       (let [proxy-port (Integer/parseInt
@@ -137,7 +137,7 @@
            headers content-type character-encoding body socket-timeout
            conn-timeout multipart debug insecure? save-request?] :as req}]
   (let [conn-mgr (or *connection-manager* (make-regular-conn-manager insecure?))
-        http-client (DefaultHttpClient. conn-mgr)]
+        http-client (DefaultHttpClient. ^org.apache.http.conn.ClientConnectionManager conn-mgr)]
     (add-client-params! http-client scheme socket-timeout
                         conn-timeout server-name)
     (let [http-url (str scheme "://" server-name


### PR DESCRIPTION
I have added proper type hints and now there are no reflective calls.

All tests pass.
