### PR TITLE
Add some more type hints to avoid reflection when `with-connection-pool` is used.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -283,4 +283,4 @@
        (try
          ~@body
          (finally
-          (.shutdown core/*connection-manager*))))))
+          (.shutdown ^org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager core/*connection-manager*))))))

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -71,7 +71,7 @@
     (.register (Scheme. "http" 80 (PlainSocketFactory/getSocketFactory)))
     (.register (Scheme. "https" 443 (SSLSocketFactory/getSocketFactory)))))
 
-(defn make-regular-conn-manager [& [insecure?]]
+(defn make-regular-conn-manager ^SingleClientConnManager [& [insecure?]]
   (if insecure?
     (SingleClientConnManager. insecure-scheme-registry)
     (SingleClientConnManager.)))
@@ -79,7 +79,9 @@
 (defn make-reusable-conn-manager
   "Given an timeout and optional insecure? flag, create a
   ThreadSafeClientConnManager with <timeout> seconds set as the timeout value."
-  [timeout & [insecure?]]
+  ;; need the fully qualified class name because this fn is later used in a macro
+  ;; from a different ns
+  ^org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager [timeout & [insecure?]]
   (let [sr (if insecure? insecure-scheme-registry regular-scheme-registry)]
     (ThreadSafeClientConnManager.
      sr timeout java.util.concurrent.TimeUnit/SECONDS)))


### PR DESCRIPTION
One hint is fully qualified because it gets used inside a macro context and using the short name may error out during compilation.
