### PR TITLE
`generate-query-string` doesn't encode sequential values properly

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -126,9 +126,17 @@
 
 (defn generate-query-string [params]
   (str/join "&"
-            (map (fn [[k v]] (str (util/url-encode (name k)) "="
-                                  (util/url-encode (str v))))
-                 params)))
+            (mapcat (fn [[k v]]
+                      (if (sequential? v)
+                        (map #(str (util/url-encode (name %1))
+                                   "="
+                                   (util/url-encode (str %2)))
+                             (repeat k) v)
+                        [(str (util/url-encode (name k))
+                              "="
+                              (util/url-encode (str v)))]))
+                    params)))
+
 
 (defn wrap-query-params [client]
   (fn [{:keys [query-params] :as req}]


### PR DESCRIPTION
Sometimes one needs to supply multiple values to a single parameter in a POST request. Currently if a vector is provided in the query map it's incorrectly encoded as is.

The attached patch fixes the problem.

Example -

```
user> (generate-query-string {:to ["a@b.com", "c@d.com"], :from "e@g.com"})
;=> "from=e%40g.com&to=%5B%22a%40b.com%22+%22c%40d.com%22%5D"
;; after fix
user> (generate-query-string {:to ["a@b.com", "c@d.com"], :from "e@g.com"})
;=> "from=e%40g.com&to=a%40b.com&to=c%40d.com"
```
