### PR TITLE
Ring Spec incompatibility

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -20,7 +20,7 @@
 
 (defn parse-url [url]
   (let [url-parsed (URL. url)]
-    {:scheme (.getProtocol url-parsed)
+    {:scheme (keyword (.getProtocol url-parsed))
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
      :uri (.getPath url-parsed)

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -114,11 +114,11 @@
 
 (defn- default-proxy-host-for
   [scheme]
-  (System/getProperty (str scheme ".proxyHost")))
+  (System/getProperty (str (name scheme) ".proxyHost")))
 
 (defn- default-proxy-port-for
   [scheme]
-  (Integer/parseInt (System/getProperty (str scheme ".proxyPort"))))
+  (Integer/parseInt (System/getProperty (str (name scheme) ".proxyPort"))))
 
 (defn add-client-params!
   "Add various client params to the http-client object, if needed."
@@ -172,7 +172,7 @@
                       ^org.apache.http.conn.ClientConnectionManager conn-mgr)]
     (add-client-params! http-client scheme socket-timeout
                         conn-timeout server-name proxy-host proxy-port)
-    (let [http-url (str scheme "://" server-name
+    (let [http-url (str (name scheme) "://" server-name
                         (when server-port (str ":" server-port))
                         uri
                         (when query-string (str "?" query-string)))

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -7,7 +7,7 @@
            (java.util Arrays)))
 
 (def base-req
-  {:scheme "http"
+  {:scheme :http
    :server-name "localhost"
    :server-port 18080})
 
@@ -38,7 +38,7 @@
         resp (r-client {:server-name "foo.com" :request-method :get})]
     (is (= 200 (:status resp)))
     (is (= :get (:request-method (:req resp))))
-    (is (= "http" (:scheme (:req resp))))
+    (is (= :http (:scheme (:req resp))))
     (is (= "/bat" (:uri (:req resp))))))
 
 (deftest redirect-to-get-on-head
@@ -52,7 +52,7 @@
         resp (r-client {:server-name "foo.com" :request-method :head})]
     (is (= 200 (:status resp)))
     (is (= :get (:request-method (:req resp))))
-    (is (= "http" (:scheme (:req resp))))
+    (is (= :http (:scheme (:req resp))))
     (is (= "/bat" (:uri (:req resp))))))
 
 (deftest pass-on-non-redirect
@@ -205,7 +205,7 @@
 (deftest apply-on-url
   (let [u-client (client/wrap-url identity)
         resp (u-client {:url "http://google.com:8080/foo?bar=bat"})]
-    (is (= "http" (:scheme resp)))
+    (is (= :http (:scheme resp)))
     (is (= "google.com" (:server-name resp)))
     (is (= 8080 (:server-port resp)))
     (is (= "/foo" (:uri resp)))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -39,7 +39,7 @@
     (future (ring/run-jetty handler {:port 18080}))))
 
 (def base-req
-  {:scheme "http"
+  {:scheme :http
    :server-name "localhost"
    :server-port 18080})
 
@@ -118,9 +118,9 @@
     (try
       (is (thrown? javax.net.ssl.SSLPeerUnverifiedException
                    (request {:request-method :get :uri "/get"
-                             :server-port 18082 :scheme "https"})))
+                             :server-port 18082 :scheme :https})))
       (let [resp (request {:request-method :get :uri "/get" :server-port 18082
-                           :scheme "https" :insecure? true})]
+                           :scheme :https :insecure? true})]
         (is (= 200 (:status resp)))
         (is (= "get" (slurp-body resp))))
       (finally
@@ -149,7 +149,7 @@
                        :body (.getBytes "foo bar")
                        :save-request? true})]
     (is (= 200 (:status resp)))
-    (is (= {:scheme "http"
+    (is (= {:scheme :http
             :http-url "http://localhost:18080/post"
             :request-method :post
             :save-request? true


### PR DESCRIPTION
Hi Dakrone,

the Ring spec says this about the :scheme option in the request map:

:scheme
  (Required, Keyword)
  The transport protocol, must be one of :http or :https.

The clj-http library is using strings for :scheme. This is not a
big deal if you use the higer level API fns suche as get, post,
etc, since they parse the :url option in the request map.

I generate some request maps with some macros and use those both
in the context of clj-http, and ring itself. When passing a
request map to clj-http that contains :scheme as a keyword it
crashes, because a url parsing fails with ":http://example.com".

Would be nice if you could merge this into master, to be more
compatible with ring.

Thx, Roman.
