### PR TITLE
adds :trace-redirects to response #45

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,8 +44,10 @@ requests. Responses are returned as Ring-style response maps:
               "cache-control" "private, max-age=0"
               "content-type" "text/html; charset=ISO-8859-1"
               ...}
-    :body "<!doctype html>..."}
+    :body "<!doctype html>..."
+    :trace-redirects ["http://google.com" "http://www.google.com/" "http://www.google.fr/"]}
 ```
+:trace-redirects will contain the chain of the redirections followed.
 
 More example requests:
 

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -191,7 +191,8 @@
   (run-server)
   (let [resp (client/get "http://localhost:18080/redirect"
                {:max-redirects 2 :throw-exceptions false})]
-    (is (= 302 (:status resp))))
+    (is (= 302 (:status resp)))
+    (is (= (apply vector (repeat 3 "http://localhost:18080/redirect")) (:trace-redirects resp))))
   (is (thrown-with-msg? Exception #"Too many redirects: 3"
         (client/get "http://localhost:18080/redirect"
                     {:max-redirects 2 :throw-exceptions true}))))


### PR DESCRIPTION
closes issue #45
This should do it. However I'm not sure if the option of adding the :trace-redirects to the response warrants adding a new parameter. I'd think this is lightweight and useful enough to be computed everytime, but maybe I'm biased.
