### PR TITLE
Allow body to be sent with HTTP GET requests.

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -50,11 +50,15 @@
         (.getParams)
         (.setParameter key val))))
 
-(defn proxy-delete-with-body [url]
-  (let [res (proxy [HttpEntityEnclosingRequestBase] []
-              (getMethod [] "DELETE"))]
-    (.setURI res (URI. url))
-    res))
+(defn make-proxy-method-with-body
+  [method]
+  (fn [url]
+    (doto (proxy [HttpEntityEnclosingRequestBase] []
+            (getMethod [] (.toUpperCase (name method))))
+      (.setURI (URI. url)))))
+
+(def proxy-delete-with-body (make-proxy-method-with-body :delete))
+(def proxy-get-with-body (make-proxy-method-with-body :get))
 
 (def ^SSLSocketFactory insecure-socket-factory
   (doto (SSLSocketFactory. (reify TrustStrategy
@@ -180,7 +184,7 @@
           req (assoc req :http-url http-url)
           #^HttpRequest
           http-req (case request-method
-                     :get    (HttpGet. http-url)
+                     :get    (proxy-get-with-body http-url)
                      :head   (HttpHead. http-url)
                      :put    (HttpPut. http-url)
                      :post   (HttpPost. http-url)

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -35,7 +35,9 @@
     [:delete "/delete-with-body"]
     {:status 200 :body "delete-with-body"}
     [:post "/multipart"]
-    {:status 200 :body (:body req)}))
+    {:status 200 :body (:body req)}
+    [:get "/get-with-body"]
+    {:status 200 :body "get-with-body"}))
 
 (defn run-server
   []
@@ -195,3 +197,9 @@
   (is (thrown-with-msg? Exception #"Too many redirects: 3"
         (client/get "http://localhost:18080/redirect"
                     {:max-redirects 2 :throw-exceptions true}))))
+
+(deftest ^{:integration true} get-with-body
+  (run-server)
+  (let [resp (request {:request-method :get :uri "/get-with-body"
+                       :body (.getBytes "foo bar")})]
+    (is (= 200 (:status resp)))))


### PR DESCRIPTION
Many applications (eg. ElasticSearch) require a payload to be sent as a part of
an HTTP GET request, but clj-http doesn't allow that right now.
This patch adds that functionality to clj-http and adds an integration test as well.
