### PR TITLE
Use preconditions to fail fast when input to client/get, client/post and so on is nil

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -308,29 +308,38 @@
   request
   (wrap-request #'core/request))
 
+(defmacro ^{ :private true } not-nil?
+  [x]
+  `(not (nil? ~x)))
+
 (defn get
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
+  { :pre [(not-nil? url)] }
   (request (merge req {:method :get :url url})))
 
 (defn head
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
+  { :pre [(not-nil? url)] }
   (request (merge req {:method :head :url url})))
 
 (defn post
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
+  { :pre [(not-nil? url)] }
   (request (merge req {:method :post :url url})))
 
 (defn put
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
+  { :pre [(not-nil? url)] }
   (request (merge req {:method :put :url url})))
 
 (defn delete
   "Like #'request, but sets the :method and :url as appropriate."
   [url & [req]]
+  { :pre [(not-nil? url)] }
   (request (merge req {:method :delete :url url})))
 
 (defmacro with-connection-pool

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -26,6 +26,17 @@
     (is (= "close" (get-in resp [:headers "connection"])))
     (is (= "get" (:body resp)))))
 
+(deftest ^{:integration true} nil-input
+  (is (thrown? AssertionError
+               (client/get nil)))
+  (is (thrown? AssertionError
+               (client/post nil)))
+  (is (thrown? AssertionError
+               (client/put nil)))
+  (is (thrown? AssertionError
+               (client/delete nil))))
+
+
 (defn is-passed [middleware req]
   (let [client (middleware identity)]
     (is (= req (client req)))))


### PR DESCRIPTION
I was debugging an issue today when a nil input to `clj-http.client/get` caused thread to block. What surprised me is that it did not produce any exceptions. I still need to investigate whether some parts of my code may be
swallowing exceptions, but making `clj-http.client/get` and friend use precondition checks sounds like a worthy idea so I went ahead and added it.
