### PR TITLE
Allow :form-params for :put requests also.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -251,7 +251,7 @@
 
 (defn wrap-form-params [client]
   (fn [{:keys [form-params request-method] :as req}]
-    (if (and form-params (= :post request-method))
+    (if (and form-params (#{:post :put} request-method))
       (client (-> req
                   (dissoc :form-params)
                   (assoc :content-type (content-type-value


### PR DESCRIPTION
This patch will allow :put requests to also take a :form-params item as PUT requests can contain a body just like POST requests.

(Faced no way to send body to a PUT endpoint, on skytap API, so I patched this).
