### PR TITLE
Added support for json in body for POST and PUT.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -250,13 +250,17 @@
       (client req))))
 
 (defn wrap-form-params [client]
-  (fn [{:keys [form-params request-method] :as req}]
+  (fn [{:keys [form-params content-type request-method]
+        :or {content-type :x-www-form-urlencoded}
+        :as req}]
     (if (and form-params (#{:post :put} request-method))
       (client (-> req
                   (dissoc :form-params)
-                  (assoc :content-type (content-type-value
-                                        :x-www-form-urlencoded)
-                         :body (generate-query-string form-params))))
+                  (assoc :content-type (content-type-value content-type)
+                         :body (({:json json/generate-string
+                                  :x-www-form-urlencoded generate-query-string}
+                                 content-type)
+                                   form-params))))
       (client req))))
 
 (defn wrap-url [client]


### PR DESCRIPTION
Currently body content is always encoded as query-params, and `:content-type` always set to the associated value for that.

This patch will support json, while query-params is still the default. If `:content-type` is set to `:json`, then `:form-params` is turned to a json string and set as the `:body`.

PS - I'm not sure of the indentation and coding style that you prefer, so you may want to refactor/rewrite this as you see fit.

Thanks.
