### PR TITLE
Introduce clj-http.client/success?, /redirect?, /client-error? and so on

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -30,6 +30,31 @@
 (def unexceptional-status?
   #{200 201 202 203 204 205 206 207 300 301 302 303 307})
 
+(defn success?
+  [{ :keys [status] }]
+  (<= 200 status 299))
+
+(defn missing?
+  [{ :keys [status] }]
+  (= status 404))
+
+(defn conflict?
+  [{ :keys [status] }]
+  (= status 409))
+
+
+(defn redirect?
+  [{ :keys [status] }]
+  (<= 300 status 399))
+
+(defn client-error?
+  [{ :keys [status] }]
+  (<= 400 status 499))
+
+(defn server-error?
+  [{ :keys [status] }]
+  (<= 500 status 599))
+
 (defn wrap-exceptions [client]
   (fn [req]
     (let [{:keys [status] :as resp} (client req)]

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -29,13 +29,13 @@
 
 (deftest ^{:integration true} nil-input
   (is (thrown-with-msg? Exception #"Host URL cannot be nil"
-               (client/get nil)))
+        (client/get nil)))
   (is (thrown-with-msg? Exception #"Host URL cannot be nil"
-               (client/post nil)))
+        (client/post nil)))
   (is (thrown-with-msg? Exception #"Host URL cannot be nil"
-               (client/put nil)))
+        (client/put nil)))
   (is (thrown-with-msg? Exception #"Host URL cannot be nil"
-               (client/delete nil))))
+        (client/delete nil))))
 
 
 (defn is-passed [middleware req]
@@ -336,3 +336,34 @@
   (is (thrown? UnknownHostException (client/get "http://aorecuf892983a.com")))
   (is (nil? (client/get "http://aorecuf892983a.com"
                         {:ignore-unknown-host? true}))))
+
+
+(deftest test-status-predicates
+  (testing "2xx statuses"
+    (doseq [s (range 200 299)]
+      (is (client/success? { :status s }))
+      (is (not (client/redirect? { :status s })))
+      (is (not (client/client-error? { :status s })))
+      (is (not (client/server-error? { :status s })))))
+  (testing "3xx statuses"
+    (doseq [s (range 300 399)]
+      (is (not (client/success? { :status s })))
+      (is (client/redirect? { :status s }))
+      (is (not (client/client-error? { :status s })))
+      (is (not (client/server-error? { :status s })))))
+  (testing "4xx statuses"
+    (doseq [s (range 400 499)]
+      (is (not (client/success? { :status s })))
+      (is (not (client/redirect? { :status s })))
+      (is (client/client-error? { :status s }))
+      (is (not (client/server-error? { :status s })))))
+  (testing "5xx statuses"
+    (doseq [s (range 500 599)]
+      (is (not (client/success? { :status s })))
+      (is (not (client/redirect? { :status s })))
+      (is (not (client/client-error? { :status s })))
+      (is (client/server-error? { :status s }))))
+  (testing "409 Conflict"
+    (is (client/conflict? { :status 409 }))
+    (is (not (client/conflict? { :status 201 })))
+    (is (not (client/conflict? { :status 404 })))))


### PR DESCRIPTION
Higher level HTTP clients like Neocons or Elastisch would often benefit from having them, makes it easier
to detect response semantics.
