### PR TITLE
Add support for cookie stores

### DIFF
--- a/src/clj_http/cookies.clj
+++ b/src/clj_http/cookies.clj
@@ -115,3 +115,9 @@
   (fn [request]
     (let [response (client (encode-cookie-header request))]
       (decode-cookie-header response))))
+
+(defn cookie-store
+  "Returns a new, empty instance of the default implementation of the
+   org.apache.http.client.CookieStore interface."
+  []
+  (org.apache.http.impl.client.BasicCookieStore.))

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -92,6 +92,7 @@
      sr timeout java.util.concurrent.TimeUnit/SECONDS)))
 
 (def ^{:dynamic true} *connection-manager* nil)
+(def ^{:dynamic true} *cookie-store* nil)
 
 (defn create-multipart-entity
   "Takes a multipart map and creates a MultipartEntity with each key/val pair
@@ -170,11 +171,13 @@
   [{:keys [request-method scheme server-name server-port uri query-string
            headers content-type character-encoding body socket-timeout
            conn-timeout multipart debug insecure? save-request? proxy-host
-           proxy-port as] :as req}]
+           proxy-port as cookie-store] :as req}]
   (let [conn-mgr (or *connection-manager* (make-regular-conn-manager insecure?))
         http-client (DefaultHttpClient.
                       ^org.apache.http.conn.ClientConnectionManager conn-mgr)
         scheme (name scheme)]
+    (when-let [cookie-store (or cookie-store *cookie-store*)]
+      (.setCookieStore http-client cookie-store))
     (add-client-params! http-client scheme socket-timeout
                         conn-timeout server-name proxy-host proxy-port)
     (let [http-url (str scheme "://" server-name


### PR DESCRIPTION
This is done using the Apache-native `BasicCookieStore` et al.  I started down the path of implementing a `wrap-cookie-store` middleware to keep everything "Clojure-native", but properly implementing the domain, path, and expiry rules for cookies is tricky enough that I'd personally rather lean on Apache for that.

No tests included, as they'd be testing the Apache lib more than anything else.  If desired, I can mock out a ring app with cookie and session middleware to do some sanity checks.
