### PR TITLE
Add support for "nested" param maps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,10 @@ More example requests:
 ;; Query parameters
 (client/get "http://site.com/search" {:query-params {"q" "foo, bar"}})
 
+;; "Nested" query parameters
+;; (this yields a query string of `a[e][f]=6&a[b][c]=5`)
+(client/get "http://site.com/search" {:query-params {:a {:b {:c 5} :e {:f 6})
+
 ;; Provide cookies — uses same schema as :cookies returned in responses
 ;; (see the cookie store option for easy cross-request maintenance of cookies)
 (client/get "http://site.com"

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -332,6 +332,19 @@
       (is (= "untouched" (:body resp)))
       (is (not (contains? resp :content-type))))))
 
+(deftest apply-on-nested-params
+  (testing "nested parameter maps"
+    (are [in out] (is-applied client/wrap-nested-params
+                              {:query-params in :form-params in}
+                              {:query-params out :form-params out})
+      {"foo" "bar"} {"foo" "bar"}
+      {"x" {"y" "z"}} {"x[y]" "z"}
+      {"a" {"b" {"c" "d"}}} {"a[b][c]" "d"}
+      {"a" "b", "c" "d"} {"a" "b", "c" "d"}))
+  
+  (testing "not creating empty param maps"
+    (is-applied client/wrap-query-params {} {})))
+
 (deftest t-ignore-unknown-host
   (is (thrown? UnknownHostException (client/get "http://aorecuf892983a.com")))
   (is (nil? (client/get "http://aorecuf892983a.com"


### PR DESCRIPTION
Corresponds with `ring.middleware.nested-params`.  Only supports nested parameter maps; I still don't quite know what to make of the "nested parameter lists" that that middleware supports (I've never seen them!).

Anyway, tests mostly aped from https://github.com/mmcgrana/ring/blob/master/ring-core/test/ring/middleware/test/nested_params.clj, just with reversed data.
