### PR TITLE
add support for :copy, :move, and :options HTTP methods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,8 +43,9 @@ Require it in your application:
   (:require [clj-http.client :as client]))
 ```
 
-The client supports simple `get`, `head`, `put`, `post`, and `delete`
-requests. Responses are returned as Ring-style response maps:
+The client supports simple `get`, `head`, `put`, `post`, `delete`,
+`copy`, `move`, and `options` requests. Responses are returned as
+Ring-style response maps:
 
 ```clojure
 (client/get "http://google.com")

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -16,6 +16,7 @@
            (org.apache.http.client HttpClient HttpRequestRetryHandler)
            (org.apache.http.client.methods HttpGet HttpHead HttpPut
                                            HttpPost HttpDelete
+                                           HttpOptions
                                            HttpEntityEnclosingRequestBase)
            (org.apache.http.client.params CookiePolicy ClientPNames)
            (org.apache.http.conn ClientConnectionManager)
@@ -59,6 +60,8 @@
 
 (def proxy-delete-with-body (make-proxy-method-with-body :delete))
 (def proxy-get-with-body (make-proxy-method-with-body :get))
+(def proxy-copy-with-body (make-proxy-method-with-body :copy))
+(def proxy-move-with-body (make-proxy-method-with-body :move))
 
 (def ^SSLSocketFactory insecure-socket-factory
   (doto (SSLSocketFactory. (reify TrustStrategy
@@ -193,11 +196,16 @@
           req (assoc req :http-url http-url)
           #^HttpRequest
           http-req (case request-method
-                     :get    (proxy-get-with-body http-url)
-                     :head   (HttpHead. http-url)
-                     :put    (HttpPut. http-url)
-                     :post   (HttpPost. http-url)
-                     :delete (proxy-delete-with-body http-url))]
+                     :get     (proxy-get-with-body http-url)
+                     :head    (HttpHead. http-url)
+                     :put     (HttpPut. http-url)
+                     :post    (HttpPost. http-url)
+                     :options (HttpOptions. http-url)
+                     :delete  (proxy-delete-with-body http-url)
+                     :copy    (proxy-copy-with-body http-url)
+                     :move    (proxy-move-with-body http-url)
+                     (throw (IllegalArgumentException.
+                              (str "Invalid request method " request-method))))]
       (when (and content-type character-encoding)
         (.addHeader http-req "Content-Type"
                     (str content-type "; charset=" character-encoding)))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -192,6 +192,10 @@
         body (slurp stream)]
     (is (= "get" body))))
 
+(deftest throw-on-invalid-body
+  (is (thrown-with-msg? IllegalArgumentException #"Invalid request method :bad"
+        (client/request {:method :bad :url "http://example.org"}))))
+
 (deftest ^{:integration true} throw-on-too-many-redirects
   (run-server)
   (let [resp (client/get "http://localhost:18080/redirect"


### PR DESCRIPTION
Q: I followed the existing `proxy-*-with-body` pattern, but I don't see a lot of use for it.  Perhaps a separate pull req to eliminate those, and turn `make-proxy-method-with-body` into a 2-arg fn that just returns the proxied `HttpEntityEnclosingRequestBase`?  My only hesitation in doing that straight off is that all the vars involved are public.
