### PR TITLE
include apache http request object when :save-request? is true

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -246,5 +246,6 @@
         (if save-request?
           (-> resp
               (assoc :request req)
+              (assoc-in [:request :http-req] http-req)
               (dissoc :save-request?))
           resp)))))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -7,7 +7,8 @@
             [clj-http.util :as util]
             [ring.adapter.jetty :as ring])
   (:import (java.io ByteArrayInputStream)
-           (org.apache.http.message BasicHeader BasicHeaderIterator)))
+           (org.apache.http.message BasicHeader BasicHeaderIterator)
+           org.apache.http.client.methods.HttpPost))
 
 (defn handler [req]
   ;;(pp/pprint req)
@@ -173,7 +174,8 @@
             :uri "/post"
             :server-name "localhost"
             :server-port 18080}
-           (dissoc (:request resp) :body)))))
+           (dissoc (:request resp) :body :http-req)))
+    (is (instance? HttpPost (-> resp :request :http-req)))))
 
 (deftest parse-headers
   (are [headers expected]


### PR DESCRIPTION
Access to the underlying apache http request object is needed in particular to be able to call [`.abort()`](http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/methods/HttpRequestBase.html#abort%28%29).  AFAICT, that's the only way to shut down a connection that is waiting on e.g. a longpoll or continuously-streaming resource (viz. CouchDB's `_changes`).
