### PR TITLE
Add support for x509 client certificates

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -93,8 +93,7 @@
     (doto (SchemeRegistryFactory/createDefault)
       (.register (Scheme. "https" 443 factory)))))
 
-(defn make-regular-conn-manager ^SingleClientConnManager [{:keys [insecure? trust-store trust-store-pass
-                                                                  keystore keystore-pass] 
+(defn make-regular-conn-manager ^SingleClientConnManager [{:keys [insecure? keystore trust-store] 
                                                            :as req}]
   (if (or (not (nil? trust-store)) (not (nil? keystore)))
     (SingleClientConnManager. (get-keystore-scheme-registry req))


### PR DESCRIPTION
I added some new parameters to the client map to support adding a keystore or trust store for x509 client certificate authentication. The code to get the connection manager is getting kind of dirty, do you have any ideas on how to refactor it?  I'm relatively new to clojure.

Best,
Paul
