### PR TITLE
Added keystore / trust-store type support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -257,8 +257,10 @@ to be used:
 
 ```clojure
 (client/get "https://example.com" {:keystore "/path/to/keystore.ks"
+                                   :keystore-type "jks" ; default: jks
                                    :keystore-pass "secretpass"
                                    :trust-store "/path/to/trust-store.ks"
+                                   :trust-store-type "jks" ; default jks
                                    :trust-store-pass "trustpass"})
 ```
 

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -24,17 +24,19 @@
     (.register (Scheme. "http" 80 (PlainSocketFactory/getSocketFactory)))
     (.register (Scheme. "https" 443 (SSLSocketFactory/getSocketFactory)))))
 
-(defn ^KeyStore get-keystore [keystore-file keystore-pass]
+(defn ^KeyStore get-keystore [keystore-file keystore-type keystore-pass]
   (when keystore-file
-    (let [keystore (KeyStore/getInstance (KeyStore/getDefaultType))]
+    (let [keystore (KeyStore/getInstance (or keystore-type
+                                             (KeyStore/getDefaultType)))]
       (with-open [is (io/input-stream keystore-file)]
         (.load keystore is (.toCharArray keystore-pass))
         keystore))))
 
 (defn get-keystore-scheme-registry
-  [{:keys [keystore keystore-pass trust-store trust-store-pass insecure?]}]
-  (let [ks (get-keystore keystore keystore-pass)
-        ts (get-keystore trust-store trust-store-pass)
+  [{:keys [keystore keystore-type keystore-pass
+           trust-store trust-store-type trust-store-pass insecure?]}]
+  (let [ks (get-keystore keystore keystore-type keystore-pass)
+        ts (get-keystore trust-store trust-store-type trust-store-pass)
         factory (SSLSocketFactory. ks keystore-pass ts)]
     (if insecure?
       (.setHostnameVerifier factory SSLSocketFactory/ALLOW_ALL_HOSTNAME_VERIFIER))

--- a/test/clj_http/test/conn_mgr.clj
+++ b/test/clj_http/test/conn_mgr.clj
@@ -20,7 +20,7 @@
     {:status 200}))
 
 (deftest load-keystore
-  (let [ks (conn-mgr/get-keystore "test-resources/keystore" "keykey")]
+  (let [ks (conn-mgr/get-keystore "test-resources/keystore" nil "keykey")]
     (is (instance? KeyStore ks))
     (is (> (.size ks) 0))))
 


### PR DESCRIPTION
I'm using `clj-http` in a project at work.  We are using the `JCEKS` keystore format.  This patch allows users to specify the keystore type for both keystore and trust-store.  Defaults to `(KeyStore/getDefaultType)`.
