### PR TITLE
Use lower-case header names, as mentioned in the Ring specification.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ More example requests:
 (client/post "http://site.com/api"
   {:basic-auth ["user" "pass"]
    :body "{\"json\": \"input\"}"
-   :headers {"X-Api-Version" "2"}
+   :headers {"x-api-version" "2"}
    :content-type :json
    :socket-timeout 1000
    :conn-timeout 1000

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -1,5 +1,7 @@
 (ns clj-http.util
   "Helper functions for the HTTP client."
+  (:require [clojure.string :refer [lower-case]]
+            [clojure.walk :refer [postwalk]])
   (:import (org.apache.commons.codec.binary Base64)
            (org.apache.commons.io IOUtils)
            (java.io ByteArrayInputStream ByteArrayOutputStream)
@@ -64,3 +66,10 @@
   [b]
   (when b
     (IOUtils/toByteArray (DeflaterInputStream. (ByteArrayInputStream. b)))))
+
+(defn lower-case-keys
+  "Recursively lower-case all map keys that are strings."
+  {:added "1.1"}
+  [m]
+  (let [f (fn [[k v]] (if (string? k) [(lower-case k) v] [k v]))]
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -176,9 +176,9 @@
 (deftest apply-on-compressed
   (let [client (fn [req]
                  (is (= "gzip, deflate"
-                        (get-in req [:headers "Accept-Encoding"])))
+                        (get-in req [:headers "accept-encoding"])))
                  {:body (util/gzip (util/utf8-bytes "foofoofoo"))
-                  :headers {"Content-Encoding" "gzip"}})
+                  :headers {"content-encoding" "gzip"}})
         c-client (client/wrap-decompression client)
         resp (c-client {})]
     (is (= "foofoofoo" (util/utf8-string (:body resp))))))
@@ -186,9 +186,9 @@
 (deftest apply-on-deflated
   (let [client (fn [req]
                  (is (= "gzip, deflate"
-                        (get-in req [:headers "Accept-Encoding"])))
+                        (get-in req [:headers "accept-encoding"])))
                  {:body (util/deflate (util/utf8-bytes "barbarbar"))
-                  :headers {"Content-Encoding" "deflate"}})
+                  :headers {"content-encoding" "deflate"}})
         c-client (client/wrap-decompression client)
         resp (c-client {})]
     (is (= "barbarbar" (util/utf8-string (:body resp))))))
@@ -201,7 +201,7 @@
 (deftest apply-on-accept
   (is-applied client/wrap-accept
               {:accept :json}
-              {:headers {"Accept" "application/json"}}))
+              {:headers {"accept" "application/json"}}))
 
 (deftest pass-on-no-accept
   (is-passed client/wrap-accept
@@ -210,7 +210,7 @@
 (deftest apply-on-accept-encoding
   (is-applied client/wrap-accept-encoding
               {:accept-encoding [:identity :gzip]}
-              {:headers {"Accept-Encoding" "identity, gzip"}}))
+              {:headers {"accept-encoding" "identity, gzip"}}))
 
 (deftest pass-on-no-accept-encoding
   (is-passed client/wrap-accept-encoding
@@ -272,7 +272,7 @@
 (deftest apply-on-basic-auth
   (is-applied client/wrap-basic-auth
               {:basic-auth ["Aladdin" "open sesame"]}
-              {:headers {"Authorization"
+              {:headers {"authorization"
                          "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="}}))
 
 (deftest pass-on-no-basic-auth
@@ -282,7 +282,7 @@
 (deftest apply-on-oauth
   (is-applied client/wrap-oauth
               {:oauth-token "my-token"}
-              {:headers {"Authorization"
+              {:headers {"authorization"
                          "Bearer my-token"}}))
 
 (deftest pass-on-no-oauth

--- a/test/clj_http/test/util.clj
+++ b/test/clj_http/test/util.clj
@@ -1,0 +1,11 @@
+(ns clj-http.test.util
+  (:require [clj-http.util :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest test-lower-case-keys
+  (are [map expected]
+    (is (= expected (lower-case-keys map)))
+    nil nil
+    {} {}
+    {"Accept" "application/json"} {"accept" "application/json"}
+    {"X" {"Y" "Z"}} {"x" {"y" "Z"}}))


### PR DESCRIPTION
Hi Lee,

The Ring SPEC says the following about the :headers key in the request
spec:

```
A Clojure map of downcased header name Strings to corresponding header
value Strings.
```

When testing HTTP clients built with clj-http against Ring handlers
the network layer is often bypassed by rebinding clj-http.core/request
and forwarding the request directly to the Ring handler. Having upper
case header names causes problems with middleware such as wrap-lint
and application code relying on lower case headers.

Using _always_ lower case headers also removes the need for code like
the following example taken from the wrap-decompression middleware.

```
(or (get-in resp-c [:headers "Content-Encoding"])
    (get-in resp-c [:headers "content-encoding"]))
```

What do you think?

Roman
