### PR TITLE
The Ring SPEC says the following about the :headers key in the request (2nd try)

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -1,5 +1,7 @@
 (ns clj-http.util
   "Helper functions for the HTTP client."
+  (:require [clojure.string :refer [lower-case]]
+            [clojure.walk :refer [postwalk]])
   (:import (org.apache.commons.codec.binary Base64)
            (org.apache.commons.io IOUtils)
            (java.io ByteArrayInputStream ByteArrayOutputStream)
@@ -64,3 +66,10 @@
   [b]
   (when b
     (IOUtils/toByteArray (DeflaterInputStream. (ByteArrayInputStream. b)))))
+
+(defn lower-case-keys
+  "Recursively lower-case all map keys that are strings."
+  {:added "1.1"}
+  [m]
+  (let [f (fn [[k v]] (if (string? k) [(lower-case k) v] [k v]))]
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -114,7 +114,7 @@
 (deftest ^{:integration true} sets-arbitrary-headers
   (run-server)
   (let [resp (request {:request-method :get :uri "/header"
-                       :headers {"X-My-Header" "header-val"}})]
+                       :headers {"x-my-header" "header-val"}})]
     (is (= "header-val" (slurp-body resp)))))
 
 (deftest ^{:integration true} sends-and-returns-byte-array-body

--- a/test/clj_http/test/util.clj
+++ b/test/clj_http/test/util.clj
@@ -1,0 +1,11 @@
+(ns clj-http.test.util
+  (:require [clj-http.util :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest test-lower-case-keys
+  (are [map expected]
+    (is (= expected (lower-case-keys map)))
+    nil nil
+    {} {}
+    {"Accept" "application/json"} {"accept" "application/json"}
+    {"X" {"Y" "Z"}} {"x" {"y" "Z"}}))


### PR DESCRIPTION
Hi Lee, 

The Ring SPEC says the following about the :headers key in the request spec:

```
A Clojure map of downcased header name Strings to corresponding header
value Strings.
```

When testing HTTP clients built with clj-http against Ring handlers
the network layer is often bypassed by rebinding clj-http.core/request
and forwarding the request directly to the Ring handler. Having upper
case header names causes problems with middleware such as wrap-lint
and application code relying on lower case headers.

Using always lower case headers also removes the need for code like
the following example taken from the wrap-decompression middleware.

```
(or (get-in resp-c [:headers "Content-Encoding"])
    (get-in resp-c [:headers "content-encoding"]))
```
