### PR TITLE
Allow requests to have multiple headers with the same name

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -211,7 +211,10 @@
       (when (instance? SingleClientConnManager conn-mgr)
         (.addHeader http-req "Connection" "close"))
       (doseq [[header-n header-v] headers]
-        (.addHeader http-req header-n header-v))
+        (if (coll? header-v)
+          (doseq [header-vth header-v]
+            (.addHeader http-req header-n header-vth))
+          (.addHeader http-req header-n header-v)))
       (if multipart
         (.setEntity #^HttpEntityEnclosingRequest http-req
                     (mp/create-multipart-entity multipart))


### PR DESCRIPTION
Legitimate HTTP requests can have the same header name repeated in the request but currently, clj-http does not allow this in the request (only in the response from what I can tell). For example, when interacting with Riak, you often have occasion to set index tags using headers and want to have multiple values for the same header name.

To make a request with multiple same named headers, use a collection
for the value.

(http/get url {:debug true :headers {"x-myheader" ["value1" "value2"]}})

...
HttpRequest:
{...
 :allHeaders
 [...
  #<BasicHeader x-myheader: value1>,
  #<BasicHeader x-myheader: value2>],
 ...}
