### PR TITLE
Don't include request query-params in redirects

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -116,9 +116,10 @@
   [client {:keys [url] :as req} {:keys [trace-redirects] :as resp}]
   (let [raw-redirect (get-in resp [:headers "location"])
         redirect (str (URL. (URL. url) raw-redirect))]
-    ((wrap-redirects client) (assoc req
-                               :url redirect
-                               :trace-redirects trace-redirects))))
+    ((wrap-redirects client) (-> req
+                                 (dissoc :query-params)
+                                 (assoc :url redirect
+                                        :trace-redirects trace-redirects)))))
 
 (defn wrap-redirects
   "Middleware that follows redirects in the response. A slingshot exception is


### PR DESCRIPTION
When clj-http gets a request like this:

``` clojure
(client/get "http://example.com/search" {:query-params {:q "foo"}})
```

And the HTTP response has the following redirection:

```
Location: http://example.com/search?q=bar
```

Then clj-http will erroneously redirect to:

```
http://example.com/search?q=foo
```

This is because the options passed to the client request override the query-string of the redirection URL. This patch fixes this bug and includes a unit test.
