### PR TITLE
handle invalid content-encoding: deflate header

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -59,7 +59,11 @@
   "Returns a zlib inflate'd version of the given byte array."
   [b]
   (when b
-    (IOUtils/toByteArray (InflaterInputStream. (ByteArrayInputStream. b)))))
+    (try
+      (IOUtils/toByteArray (InflaterInputStream. (ByteArrayInputStream. b)))
+      (catch java.util.zip.ZipException e ;broken inflate implementation server-side,
+                                          ; see http://stackoverflow.com/questions/3932117/handling-http-contentencoding-deflate
+        (IOUtils/toByteArray (InflaterInputStream. (ByteArrayInputStream. b) (java.util.zip.Inflater. true)))))))
 
 (defn deflate
   "Returns a deflate'd version of the given byte array."


### PR DESCRIPTION
fix for a broker server-side inflate implementation, for explaination please see http://stackoverflow.com/questions/3932117/handling-http-contentencoding-deflate
