### PR TITLE
Allow JSON coersion for error responses

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -242,8 +242,7 @@
          (read-string (String. #^"[B" body "UTF-8")))
 
        (and (.startsWith (str typestring) "application/json")
-            json-enabled?
-            (unexceptional-status? status))
+            json-enabled?)
        (if-let [charset (second (re-find #"charset=(.*)"
                                          (str typestring)))]
          (json-decode (String. #^"[B" body ^String charset) true)


### PR DESCRIPTION
I removed the test for unexceptional-status from :auto response body coesion because the content-type says already application/json and JSON error responses are not impossible.

I have a server which responses with a well defined JSON structure in the case of an error. The content type of such responses is also correctly set to application/json.

I found the related issue [:as :json may hide status code errors with parse errors](https://github.com/dakrone/clj-http/issues/71) where you introduced the unexceptional-status test. This may be necessary for :as :json but I don't think its helpful for :as :auto.
