### PR TITLE
Read EDN data, not Clojure data and recognize application/edn.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :dependencies [[org.apache.httpcomponents/httpcore "4.2.3"]
                  [org.apache.httpcomponents/httpclient "4.2.2"]
                  [org.apache.httpcomponents/httpmime "4.2.2"]
+                 [org.clojure/tools.reader "0.7.3"]
                  [commons-codec "1.6"]
                  [commons-io "2.4"]
                  [slingshot "0.10.3"]


### PR DESCRIPTION
Hi Lee,

I changed the coerce-response-body multi methods to use the
read-string fn from clojure.tools.reader, which is the
recommended way to read EDN/Clojure data these days. Clojure's
read-string fn is considered harmful, even with _read-eval_ bound
to false.

Would you like to merge this into master?

Thanks, Roman,
