### PR TITLE
Handle user defined tagged literals when parsing application/edn.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -42,7 +42,8 @@
   [& args]
   {:pre [edn-enabled?]}
   (apply (ns-resolve (symbol "clojure.tools.reader.edn")
-                     (symbol "read-string")) args))
+                     (symbol "read-string"))
+         {:readers @(resolve '*data-readers*)} args))
 
 (defn ^:dynamic parse-html
   "Resolve and apply crouton's HTML parsing."


### PR DESCRIPTION
Users can define their own tagged literals via data_readers.clj or
associng them to _data-readers_. This map has to be passed into
clojure.edn/read-string or clojure.tools.reader.edn/read-string as the
first argument. Otherwise they won't get recognized and an exception
is thrown. With this change edn/read-string has the same behaviour as
core/read-string minus the security problems.
