### PR TITLE
two small fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
-  :aliases {"all" ["with-profile" "dev,1.3:dev,1.4:dev"]}
+  :aliases {"all" ["with-profile" "dev,1.2:dev,1.3:dev,1.4:dev"]}
   :plugins [[codox "0.6.4"]]
   :test-selectors {:default  #(not (:integration %))
                    :integration :integration


### PR DESCRIPTION
added 1.2 back into the all alias, i'm not sure when it went missing

bumped httpcore version up a patch release
