### PR TITLE
url-encode any illegal characters in the path of the URL being parsed 

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -69,6 +69,12 @@
 (defn when-pos [v]
   (when (and v (pos? v)) v))
 
+(defn url-encode-path
+  "Takes a raw path and url-encodes any illegal characters."
+  [path]
+  (str/replace path
+    #"[^a-zA-Z0-9\.\-\_\~\!\$\&\'\(\)\*\+\,\;\=\:\@\/\%]" util/url-encode))
+
 (defn parse-url
   "Parse a URL string into a map of interesting parts."
   [url]
@@ -76,7 +82,7 @@
     {:scheme (keyword (.getProtocol url-parsed))
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
-     :uri (.getPath url-parsed)
+     :uri (url-encode-path (.getPath url-parsed))
      :user-info (.getUserInfo url-parsed)
      :query-string (.getQuery url-parsed)}))
 

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -342,11 +342,11 @@
 
 (deftest apply-on-url
   (let [u-client (client/wrap-url identity)
-        resp (u-client {:url "http://google.com:8080/foo?bar=bat"})]
+        resp (u-client {:url "http://google.com:8080/baz foo?bar=bat"})]
     (is (= :http (:scheme resp)))
     (is (= "google.com" (:server-name resp)))
     (is (= 8080 (:server-port resp)))
-    (is (= "/foo" (:uri resp)))
+    (is (= "/baz+foo" (:uri resp)))
     (is (= "bar=bat" (:query-string resp)))))
 
 (deftest pass-on-no-url
@@ -514,3 +514,12 @@
     (is (= "close" (get-in resp2 [:headers "connection"]))
         "connection should be closed")
     (.shutdown cm)))
+
+(deftest test-url-encode-path
+  (is (= (client/url-encode-path "foo bar+baz[]75") "foo+bar+baz%5B%5D75"))
+  (let [all-chars (apply str (map char (range 256)))
+        all-chars-encoded (client/url-encode-path all-chars)] ;fixed point
+    (is (= all-chars-encoded (client/url-encode-path all-chars-encoded)))))
+
+
+         


### PR DESCRIPTION
This pull request attempts to gracefully handle situations where a URL contains illegal characters in the path, for example:
"http://www.sears.com/search=slow cooker"
results in a path of
"/search=slow cooker"
Note that the equal sign is legal, but the space is not. This new code converts the path to
"/search=slow+cooker"

I encountered such an invalid URL at the end of a chain of redirects, which caused an exception to be thrown, preventing the GET request to the URL.
