### PR TITLE
Potential fix for Issue 125

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -87,10 +87,17 @@
         (set-client-param client ConnRoutePNames/FORCED_ROUTE route)))
     request))
 
-(defn- cookie-spec [f] (proxy [BrowserCompatSpec] []
+(defn cookie-spec 
+  "Create an instance of a org.apache.http.impl.cookie.BrowserCompatSpec with a validate function
+  that you pass in.  This function takes two parameters, a cookie and an origin."
+  [f] (proxy [BrowserCompatSpec] []
                         (validate [cookie origin] (f cookie origin))))
 
-(defn- cookie-spec-factory [f] (proxy [CookieSpecFactory] []
+(defn cookie-spec-factory 
+  "Create an instance of a org.apache.http.cookie.CookieSpecFactory with a newInstance implementation
+  that returns a cookie specification with a validate function that you pass in.  The function takes
+  two parameters: cookie and origin."
+  [f] (proxy [CookieSpecFactory] []
                            (newInstance [params] (cookie-spec f))))
 
 (defn add-client-params!
@@ -99,7 +106,7 @@
   (let [cookie-policy (:cookie-policy kvs)
         cookie-policy-name (str (type cookie-policy))                
         kvs (dissoc kvs :cookie-policy)]
-    (when cookie-spec-factory
+    (when cookie-policy
       (-> http-client 
         .getCookieSpecs 
         (.register cookie-policy-name (cookie-spec-factory cookie-policy))))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -12,7 +12,11 @@
            (org.apache.http.client.methods HttpPost)
            (org.apache.http HttpResponse HttpConnection HttpVersion)
            (org.apache.http.protocol HttpContext ExecutionContext)
-           (org.apache.http.impl.client DefaultHttpClient)))
+           (org.apache.http.impl.client DefaultHttpClient)
+           (org.apache.http.cookie CookieSpecFactory)
+           (org.apache.http.impl.cookie BrowserCompatSpec)
+           (org.apache.http.client.params CookiePolicy ClientPNames)
+           (org.apache.http.cookie.params CookieSpecPNames)))
 
 (defn handler [req]
   ;;(pp/pprint req)
@@ -414,6 +418,21 @@
                               (core/add-client-params! ps)))]
       (doseq [[k v] ps]
         (is (= v (.getParameter setps k)))))))
+
+;; If you don't explicitly set a :cookie-policy, use CookiePolicy/BROWSER_COMPATIBILITY 
+(deftest t-add-client-params-default-cookie-policy
+  (testing "Using add-client-params! to get a default cookie policy"
+    (let [setps (.getParams (doto (DefaultHttpClient.)
+                              (core/add-client-params! {})))]      
+        (is (= CookiePolicy/BROWSER_COMPATIBILITY (.getParameter setps ClientPNames/COOKIE_POLICY))))))
+
+;; If you set a :cookie-policy, the name of the policy is registered as (str (type cookie-policy))
+(deftest t-add-client-params-default-cookie-policy
+  (testing "Using add-client-params! to get an explicitly set :cookie-policy"
+    (let [setps (.getParams (doto (DefaultHttpClient.)
+                              (core/add-client-params! {:cookie-policy (constantly nil)})))]      
+        (is (.startsWith (.getParameter setps ClientPNames/COOKIE_POLICY) "class ")))))
+
 
 ;; This relies on connections to writequit.org being slower than 1ms, if this
 ;; fails, you must have very nice internet.


### PR DESCRIPTION
I've got a day's knowledge of Git/hub, and I've only been programming in Clojure for a couple of weeks, so I'm probably doing this wrong.  But, maybe this will be somewhat helpful. This includes my fix.  

I've added a new :client-param named :cookie-spec-factory.  If you set this to a value, the add-client-params! function will register the factory and set the policy name to the name of the cookie spec factory class name.  I felt this was a good way to ensure you don't register over another already registered factory. If you don't set the :cookie-spec-factory, it defaults to CookiePolicy/BROWSER_COMPATIBILITY for backwards compatibility.

Here's an example of how I used this new code:

``` clojure
(def easy-cookie-spec (proxy [BrowserCompatSpec] []
                        (validate [cookie origin] nil)))

(def cookie-spec-factory (proxy [CookieSpecFactory] []
                           (newInstance [params] easy-cookie-spec)))

(defn login [cookie-store]
  (client/post "http://a.url.com" {:form-params { ;;;;;;whatever form params you're setting
                                                                                 }
                                                                   :cookie-store cookie-store
                                                                   :client-params {:cookie-spec-factory cookie-spec-factory}
                                                                   }))
```

Also, regardless of whether you accept this, I'd love some feedback on what I'm doing wrong here (whether it's with git/hub or with clojure).  Thanks!
