### PR TITLE
Encode illegal characters in query as well as path.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -68,12 +68,15 @@
 (defn when-pos [v]
   (when (and v (pos? v)) v))
 
-(defn url-encode-path
-  "Takes a raw path and url-encodes any illegal characters."
-  [path]
-  (str/replace path
-               #"[^a-zA-Z0-9\.\-\_\~\!\$\&\'\(\)\*\+\,\;\=\:\@\/\%]"
-               util/url-encode))
+(defn url-encode-illegal-characters
+  "Takes a raw url path or query and url-encodes any illegal characters.
+   Minimizes ambiguity by encoding space to %20."
+  [path-or-query]
+  (when path-or-query
+    (-> path-or-query
+        (str/replace " " "%20")
+        (str/replace #"[^a-zA-Z0-9\.\-\_\~\!\$\&\'\(\)\*\+\,\;\=\:\@\/\%\?]"
+                     util/url-encode))))
 
 (defn parse-url
   "Parse a URL string into a map of interesting parts."
@@ -82,9 +85,9 @@
     {:scheme (keyword (.getProtocol url-parsed))
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
-     :uri (url-encode-path (.getPath url-parsed))
+     :uri (url-encode-illegal-characters (.getPath url-parsed))
      :user-info (.getUserInfo url-parsed)
-     :query-string (.getQuery url-parsed)}))
+     :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
 
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -342,12 +342,12 @@
 
 (deftest apply-on-url
   (let [u-client (client/wrap-url identity)
-        resp (u-client {:url "http://google.com:8080/baz foo?bar=bat"})]
+        resp (u-client {:url "http://google.com:8080/baz foo?bar=bat bit?"})]
     (is (= :http (:scheme resp)))
     (is (= "google.com" (:server-name resp)))
     (is (= 8080 (:server-port resp)))
-    (is (= "/baz+foo" (:uri resp)))
-    (is (= "bar=bat" (:query-string resp)))))
+    (is (= "/baz%20foo" (:uri resp)))
+    (is (= "bar=bat%20bit?" (:query-string resp)))))
 
 (deftest pass-on-no-url
   (let [u-client (client/wrap-url identity)
@@ -516,7 +516,8 @@
     (.shutdown cm)))
 
 (deftest test-url-encode-path
-  (is (= (client/url-encode-path "foo bar+baz[]75") "foo+bar+baz%5B%5D75"))
+  (is (= (client/url-encode-illegal-characters "?foo bar+baz[]75")
+         "?foo%20bar+baz%5B%5D75"))
   (is (= (str "/:@-._~!$&'()*+,="
               ";"
               ":@-._~!$&'()*+,"
@@ -528,5 +529,6 @@
                      ",=:@-._~!$&'()*+,==?/?:@-._~!$'()*+,;=/?:@-._~!$'("
                      ")*+,;==#/?:@-._~!$&'()*+,;=")))))
   (let [all-chars (apply str (map char (range 256)))
-        all-chars-encoded (client/url-encode-path all-chars)] ;fixed point
-    (is (= all-chars-encoded (client/url-encode-path all-chars-encoded)))))
+        all-legal (client/url-encode-illegal-characters all-chars)] 
+    (is (= all-legal
+           (client/url-encode-illegal-characters all-legal)))))


### PR DESCRIPTION
So we:
1. Change url-encode-path to url-encode-illegal-characters
2. Encode space to %20 to avoid clashes with + character
3. Disallow encoding of ? (legal in query and nonexistent in path)

Tests updated to reflect these changes.
