### PR TITLE
fixes streaming in multipart contents if you know the length

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -41,11 +41,11 @@
    (and content name length)
    (if mime-type
      (proxy [InputStreamBody] [content mime-type name]
-       (getContentLength []
-         length))
+       (getContentLength [] length)
+       (isStreaming [] false))
      (proxy [InputStreamBody] [content name]
-       (getContentLength []
-         length)))
+       (getContentLength [] length)
+       (isStreaming [] false)))
 
    (and content mime-type name)
    (InputStreamBody. content mime-type name)


### PR DESCRIPTION
If you don't set isStreaming to false it ignores the length and tries to chunk, which is probably not what you want if you do know the length.
