### PR TITLE
Don't shutdown reusable connection manager on error

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -11,8 +11,10 @@
            (org.apache.http.conn.scheme PlainSocketFactory
                                         SchemeRegistry Scheme)
            (org.apache.http.impl.conn BasicClientConnectionManager
-                                      SchemeRegistryFactory)
-           (org.apache.http.impl.conn PoolingClientConnectionManager)))
+                                      PoolingClientConnectionManager
+                                      ProxySelectorRoutePlanner
+                                      SchemeRegistryFactory
+                                      SingleClientConnManager)))
 
 (def ^SSLSocketFactory insecure-socket-factory
   (SSLSocketFactory. (reify TrustStrategy
@@ -101,6 +103,10 @@
      registry timeout java.util.concurrent.TimeUnit/SECONDS)))
 
 (def dmcpr ConnPerRouteBean/DEFAULT_MAX_CONNECTIONS_PER_ROUTE)
+
+(defn reusable? [^ClientConnectionManager conn-mgr]
+  (not (or (instance? SingleClientConnManager conn-mgr)
+           (instance? BasicClientConnectionManager conn-mgr))))
 
 (defn make-reusable-conn-manager
   "Creates a default pooling connection manager with the specified options.


### PR DESCRIPTION
When a request fails, only shutdown the connection manager if it's
single use. If the connection manager is reusable, it should be left
open so that it can be used by subsequent requests.

Closes #150.

Note: I've tried to keep the behaviour for `coerce-body-entity` and the `Connection: close` header identical to how it existed before my changes, just in-case anyone is doing something strange like implementing their own `ClientConnectionManager`. This means that I define `clj-http.conn-mgr/reusable?` like:

``` clj
(defn reusable? [^ClientConnectionManager conn-mgr]
  (not (or (instance? SingleClientConnManager conn-mgr)
           (instance? BasicClientConnectionManager conn-mgr))))
```

instead of:

``` clj
(defn reusable? [^ClientConnectionManager conn-mgr]
  (instance? PoolingClientConnectionManager conn-mgr))
```

even though the latter might seem a bit more intuitive. The end result is that custom ClientConnectionManager types are still treated as reusable, not single-use.
