### PR TITLE
query-params should not clobber query-string

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -497,8 +497,12 @@
   (fn [{:keys [query-params] :as req}]
     (if query-params
       (client (-> req (dissoc :query-params)
-                  (assoc :query-string
-                    (generate-query-string query-params))))
+                  (update-in [:query-string]
+                             (fn [old-query-string new-query-string]
+                               (if-not (empty? old-query-string)
+                                 (str old-query-string "&" new-query-string)
+                                 new-query-string))
+                             (generate-query-string query-params))))
       (client req))))
 
 (defn basic-auth-value [basic-auth]

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -344,7 +344,11 @@
 (deftest apply-on-query-params
   (is-applied client/wrap-query-params
               {:query-params {"foo" "bar" "dir" "<<"}}
-              {:query-string "foo=bar&dir=%3C%3C"}))
+              {:query-string "foo=bar&dir=%3C%3C"})
+  (is-applied client/wrap-query-params
+              {:query-string "foo=1"
+               :query-params {"foo" ["2" "3"]}}
+              {:query-string "foo=1&foo=2&foo=3"}))
 
 (deftest pass-on-no-query-params
   (is-passed client/wrap-query-params


### PR DESCRIPTION
A fix for issue #152 

This only solves just the issue that @leathekd brings up -- it allows you to use an url with a query component along with a query-params map. There are some other corner cases that could be handled by rejiggering things more, but I thought that should probably wait until another day, since the change will be bigger.
