### PR TITLE
Add :raw-headers option to preserve response headers verbatim

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -466,6 +466,28 @@ response map. This is particularly useful for paging RESTful APIs:
     :last {:href "https://api.github.com/gists?page=22884"}}
 ```
 
+### Raw headers
+By default clj-http forces lowercase header names when parsing the
+response. If you want to preserve the exact response headers (with their
+original casing), you can use the `:raw-headers` option on your request.
+When you add this option you'll receive both the usual downcased headers
+_and_ an additional map of raw headers in your response.
+
+```clojure
+(client/get "http://google.com" {:raw-headers true})
+=> {:status 200
+    :headers {"date" "Sun, 01 Aug 2010 07:03:49 GMT"
+              "cache-control" "private, max-age=0"
+              "content-type" "text/html; charset=ISO-8859-1"
+              ...}
+    :raw-headers {"Date" "Sun, 01 Aug 2010 07:03:49 GMT"
+                  "Cache-Control" "private, max-age=0"
+                  "Content-Type" "text/html; charset=ISO-8859-1"
+                  ...}
+    ...
+
+```
+
 ### Using persistent connections
 clj-http can use persistent connections to speed up connections if
 multiple connections are being used:

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -144,7 +144,13 @@
 (deftest ^{:integration true} returns-arbitrary-headers
   (run-server)
   (let [resp (request {:request-method :get :uri "/get"})]
-    (is (string? (get-in resp [:headers "date"])))))
+    (is (string? (get-in resp [:headers "date"])))
+    (is (nil? (get-in resp [:headers "Date"])))))
+
+(deftest ^{:integration true} returns-raw-headers
+  (run-server)
+  (let [resp (request {:request-method :get :uri "/get" :raw-headers true})]
+    (is (string? (get-in resp [:raw-headers "Date"])))))
 
 (deftest ^{:integration true} returns-status-on-exceptional-responses
   (run-server)


### PR DESCRIPTION
Since `parse-headers` is not a private fn I've tried to leave the signature the same. This means parsing the headers twice but it feels like the safest way to make the change.

Closes #155
