### PR TITLE
Updated httpclient dependency version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
   :min-lein-version "2.0.0"
   :exclusions [org.clojure/clojure]
   :dependencies [[org.apache.httpcomponents/httpcore "4.3.1"]
-                 [org.apache.httpcomponents/httpclient "4.3.1"]
-                 [org.apache.httpcomponents/httpmime "4.3.1"]
+                 [org.apache.httpcomponents/httpclient "4.3.2"]
+                 [org.apache.httpcomponents/httpmime "4.3.2"]
                  [commons-codec "1.9"]
                  [commons-io "2.4"]
                  [slingshot "0.10.3"]


### PR DESCRIPTION
To support SNI and small bugfixes as written here:
https://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.3.x.txt
http://en.wikipedia.org/wiki/Server_Name_Indication

All tests passing
