### PR TITLE
Added wrap-form-params support to the PATCH method

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -585,7 +585,7 @@
   (fn [{:keys [form-params content-type request-method json-opts]
         :or {content-type :x-www-form-urlencoded}
         :as req}]
-    (if (and form-params (#{:post :put} request-method))
+    (if (and form-params (#{:post :put :patch} request-method))
       (client (-> req
                   (dissoc :form-params)
                   (assoc :content-type (content-type-value content-type)

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -455,6 +455,14 @@
       (is (= "application/json" (:content-type resp)))
       (is (not (contains? resp :form-params))))
     (let [param-client (client/wrap-form-params identity)
+          params {:param1 "value1" :param2 "value2"}
+          resp (param-client {:request-method :patch
+                              :content-type :json
+                              :form-params params})]
+      (is (= (json/encode params) (:body resp)))
+      (is (= "application/json" (:content-type resp)))
+      (is (not (contains? resp :form-params))))
+    (let [param-client (client/wrap-form-params identity)
           params {:param1 (java.util.Date. (long 0))}
           resp (param-client {:request-method :put
                               :content-type :json


### PR DESCRIPTION
While developing an app that uses patch I found that this has not yet been implemented.
Seemed easier to fix and submit a pull request than ask why it was left out.

Please let me know if this has been skipped for a reason.
