### PR TITLE
Added support for nil password when none specified

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -96,7 +96,7 @@
     (let [keystore (KeyStore/getInstance (or keystore-type
                                              (KeyStore/getDefaultType)))]
       (with-open [is (io/input-stream keystore-file)]
-        (.load keystore is (.toCharArray keystore-pass))
+        (.load keystore is (when keystore-pass (.toCharArray keystore-pass)))
         keystore))))
 
 (defn ^SchemeRegistry get-keystore-scheme-registry

--- a/test/clj_http/test/conn_mgr.clj
+++ b/test/clj_http/test/conn_mgr.clj
@@ -26,6 +26,10 @@
     (is (instance? KeyStore ks))
     (is (> (.size ks) 0))))
 
+(deftest load-keystore-with-nil-pass
+  (let [ks (conn-mgr/get-keystore "test-resources/keystore" nil nil)]
+    (is (instance? KeyStore ks))))
+
 (deftest keystore-scheme-factory
   (let [sr (conn-mgr/get-keystore-scheme-registry
             {:keystore client-ks :keystore-pass client-ks-pass


### PR DESCRIPTION
A null pointer was thrown previously when nil or no trust-store-pass was set.
