### PR TITLE
Add Transit JSON/MessagePack support

### DIFF
--- a/README.org
+++ b/README.org
@@ -149,6 +149,16 @@ More example requests:
                                :content-type :json
                                :json-opts {:date-format "yyyy-MM-dd"})
 
+;; Send form params as a Transit encoded JSON body (POST or PUT) with options
+(client/post "http://site.com" {:form-params {:foo "bar"}
+                                :content-type :transit+json
+                                :transit-opts {:handlers {}}})
+
+;; Send form params as a Transit encoded MessagePack body (POST or PUT) with options
+(client/post "http://site.com" {:form-params {:foo "bar"}
+                                :content-type :transit+msgpack
+                                :transit-opts {:handlers {}}})
+
 ;; Multipart form uploads/posts
 ;; takes a vector of maps, to preserve the order of entities, :name
 ;; will be used as the part name unless :part-name is specified
@@ -246,6 +256,10 @@ content encodings.
 (client/get "http://site.com/foo.json" {:as :json-strict})
 (client/get "http://site.com/foo.json" {:as :json-string-keys})
 (client/get "http://site.com/foo.json" {:as :json-strict-string-keys})
+
+;; Coerce as Transit encoded JSON or MessagePack
+(client/get "http://site.com/foo" {:as :transit+json})
+(client/get "http://site.com/foo" {:as :transit+msgpack})
 
 ;; Coerce as a clojure datastructure
 (client/get "http://site.com/foo.clj" {:as :clojure})

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [org.apache.httpcomponents/httpmime "4.3.5"]
                  [commons-codec "1.9"]
                  [commons-io "2.4"]
+                 [com.cognitect/transit-clj "0.8.247"]
                  [slingshot "0.10.3"]
                  [cheshire "5.3.1"]
                  [crouton "0.1.2"]


### PR DESCRIPTION
This PR adds Transit JSON/MessagePack support. `:form-params` encoding
is triggered by setting the `:content-type` to either `:transit+json` or
`:transit+msgpack`. Response body decoding is triggered by setting `:as`
to `:transit+json`, `:transit+msgpack` or just `:auto`.

The `wrap-form-params` middleware has been refactored to call the
`coerce-form-params` multi method to enable pluggable form encoding in a
similar fashion as we have done with `coerce-response-body`.
