### PR TITLE
Fix :json-strict-string-keys

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -367,7 +367,7 @@
   (coerce-json-body req resp true true))
 
 (defmethod coerce-response-body :json-strict-string-keys [req resp]
-  (coerce-json-body req resp true true))
+  (coerce-json-body req resp false true))
 
 (defmethod coerce-response-body :json-string-keys [req resp]
   (coerce-json-body req resp false false))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -357,6 +357,8 @@
         resp-array (client/get (localhost "/json-array") {:as :json-strict})
         resp-str (client/get (localhost "/json")
                              {:as :json :coerce :exceptional})
+        resp-str-keys (client/get (localhost "/json") {:as :json-string-keys})
+        resp-strict-str-keys (client/get (localhost "/json") {:as :json-strict-string-keys})
         resp-auto (client/get (localhost "/json") {:as :auto})
         bad-resp (client/get (localhost "/json-bad")
                              {:throw-exceptions false :as :json})
@@ -370,12 +372,17 @@
            (:status resp)
            (:status resp-array)
            (:status resp-str)
+           (:status resp-str-keys)
+           (:status resp-strict-str-keys)
            (:status resp-auto)))
     (is (= {:foo "bar"}
            (:body resp)
            (:body resp-auto)))
     (is (= ["foo", "bar"]
            (:body resp-array)))
+    (is (= {"foo" "bar"}
+           (:body resp-strict-str-keys)
+           (:body resp-str-keys)))
     ;; '("foo" "bar") and ["foo" "bar"] compare as equal with =.
     (is (vector? (:body resp-array)))
     (is (= "{\"foo\":\"bar\"}" (:body resp-str)))


### PR DESCRIPTION
Make decoded JSON keys actually be strings in :json-strict-string-keys
mode.  Prior to this patch you'd get strict parsing behaviour, but the
keys would still be keywords (looks like copy-paste bug from two lines
above).

Also added very basic tests to cover string-keys.
