### PR TITLE
Allow scheme customisation in default connection

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -126,7 +126,7 @@
 
    (opt req :insecure) (BasicClientConnectionManager. insecure-scheme-registry)
 
-   :else (BasicClientConnectionManager.)))
+   :else (BasicClientConnectionManager. regular-scheme-registry)))
 
 ;; need the fully qualified class name because this fn is later used in a
 ;; macro from a different ns


### PR DESCRIPTION
In order to allow use of custom URL schemas, ensure that the scheme registry
is used.

Use regular-scheme-registry in make-regular-conn-manager for the default case.
