### PR TITLE
Fix wrap-nested-params for non-form content-types

### DIFF
--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -73,7 +73,7 @@
     [:get "/header"]
     {:status 200 :body (get-in req [:headers "x-my-header"])}
     [:post "/post"]
-    {:status 200 :body (slurp (:body req))}
+    {:status 200 :body (:body req)}
     [:get "/error"]
     {:status 500 :body "o noes"}
     [:get "/timeout"]
@@ -100,7 +100,7 @@
 (defn run-server
   []
   (defonce server
-    (ring/run-jetty handler {:port 18080 :join? false})))
+    (ring/run-jetty #'handler {:port 18080 :join? false})))
 
 (defn localhost [path]
   (str "http://localhost:18080" path))


### PR DESCRIPTION
The `wrap-nested-params` always kicked in, except when the :content-type
was set to :json. When sending nested structures as :edn or :transit the
payload got also nested. This PR fixes that problem, by only nesting if
there is no content type set (which defaults to x-www-form-urlencoded)
or if the content type is x-www-form-urlencoded.
