### PR TITLE
Avoid deprecated FileBody constructors and clear up reflection warning.

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -14,19 +14,19 @@
 
 (defn make-file-body
   "Create a FileBody object from the given map, requiring at least :content"
-  [{:keys [name ^String mime-type ^File content ^String encoding]}]
+  [{:keys [^String name ^String mime-type ^File content ^String encoding]}]
   (cond
    (and name mime-type content encoding)
-   (FileBody. content name mime-type encoding)
+   (FileBody. content (ContentType/create mime-type encoding) name)
 
    (and mime-type content encoding)
-   (FileBody. content mime-type encoding)
+   (FileBody. content (ContentType/create mime-type encoding))
 
    (and name mime-type content)
    (FileBody. content (ContentType/create mime-type) name)
 
    (and mime-type content)
-   (FileBody. content mime-type)
+   (FileBody. content (ContentType/create mime-type))
 
    content
    (FileBody. content)

--- a/test/clj_http/test/multipart.clj
+++ b/test/clj_http/test/multipart.clj
@@ -1,0 +1,44 @@
+(ns clj-http.test.multipart
+  (:require [clj-http.multipart :refer :all]
+            [clojure.test :refer :all])
+  (:import (java.io File)
+           (org.apache.http.entity.mime.content FileBody)))
+
+(deftest test-make-file-body
+  (testing "no content throws exception"
+    (is (thrown? Exception (make-file-body {}))))
+
+  (testing "can create FileBody with content only"
+    (let [testfile (File. "testfile")
+          file-body (make-file-body {:content (File. "testfile")})]
+      (is (= (.getFile ^FileBody file-body) testfile))))
+
+  (testing "can create FileBody with content and mime-type"
+    (let [testfile (File. "testfile")
+          file-body (make-file-body {:content (File. "testfile")
+                                     :mime-type "application/octet-stream"})]
+      (is (= (.getFile ^FileBody file-body) testfile))))
+
+  (testing "can create FileBody with content and mime-type and name"
+    (let [testfile (File. "testfile")
+          file-body (make-file-body {:content (File. "testfile")
+                                     :mime-type "application/octet-stream"
+                                     :name "testname"})]
+      (is (= (.getFile ^FileBody file-body) testfile))
+      (is (= (.getFilename ^FileBody file-body) "testname"))))
+
+  (testing "can create FileBody with content and mime-type and encoding"
+    (let [testfile (File. "testfile")
+          file-body (make-file-body {:content (File. "testfile")
+                                     :mime-type "application/octet-stream"
+                                     :encoding "utf-8"})]
+      (is (= (.getFile ^FileBody file-body) testfile))))
+
+  (testing "can create FileBody with content and mime-type and encoding and name"
+    (let [testfile (File. "testfile")
+          file-body (make-file-body {:content (File. "testfile")
+                                     :mime-type "application/octet-stream"
+                                     :encoding "utf-8"
+                                     :name "testname"})]
+      (is (= (.getFile ^FileBody file-body) testfile))
+      (is (= (.getFilename ^FileBody file-body) "testname")))))


### PR DESCRIPTION
Just happened to notice some deprecated constructors being used. Wrote a minimal test as well.
