### PR TITLE
clj-http.headers/HeaderMap should implement functions 'meta' and 'with-meta'

### DIFF
--- a/src/clj_http/headers.clj
+++ b/src/clj_http/headers.clj
@@ -102,28 +102,33 @@
 ;; other operations using the normalized -- this allows a value to be
 ;; looked up by many similar keys, and not just the exact precise key
 ;; it was originally stored with.
-(potemkin/def-map-type HeaderMap [m]
+(potemkin/def-map-type HeaderMap [m mta]
   (get [_ k v]
     (second (get m (normalize k) [nil v])))
   (assoc [_ k v]
     (HeaderMap. (assoc m (normalize k) [(if (keyword? k)
                                           (canonicalize k)
                                           k)
-                                        v])))
+                                        v])
+                mta))
   (dissoc [_ k]
-    (HeaderMap. (dissoc m (normalize k))))
+    (HeaderMap. (dissoc m (normalize k)) mta))
   (keys [_]
     (map first (vals m)))
+  (meta [_]
+    mta)
+  (with-meta [_ mta]
+    (HeaderMap. m mta))
   clojure.lang.Associative
   (containsKey [_ k]
     (contains? m (normalize k)))
   (empty [_]
-    (HeaderMap. {})))
+    (HeaderMap. {} nil)))
 
 (defn header-map
   "Returns a new header map with supplied mappings."
   [& keyvals]
-  (into (HeaderMap. {})
+  (into (HeaderMap. {} nil)
         (apply array-map keyvals)))
 
 (defn wrap-header-map

--- a/test/clj_http/test/headers.clj
+++ b/test/clj_http/test/headers.clj
@@ -64,7 +64,9 @@
     (is (= "eggs" (m2 "ham")))
     (is (= "nope" (get m2 "absent" "nope")))
     (is (= "baz" (:foo (merge (header-map :foo "bar")
-                              {"Foo" "baz"}))))))
+                              {"Foo" "baz"}))))
+    (let [m-with-meta (with-meta m {:withmeta-test true})]
+      (is (= (:withmeta-test (meta m-with-meta)) true)))))
 
 (deftest test-empty
   (testing "an empty header-map is a header-map"


### PR DESCRIPTION
clj-http.headers/HeaderMap doesn't implement 'meta' and 'with-meta', although the documentation of def-map-type of potemkin library says it should be implemented.

Some libraries (like Midje) use 'with-meta' on clojure data. cli-http throws java.lang.AbstractMethodError with those libraries because of the lack of 'with-meta'.

