### PR TITLE
Connection leak when HttpEntry is null 

### DIFF
--- a/test/clj_http/test/conn_mgr.clj
+++ b/test/clj_http/test/conn_mgr.clj
@@ -79,3 +79,17 @@
       (is false "request should have thrown an exception")
       (catch Exception e))
     (is @shutdown? "Connection manager has been shut down")))
+
+(deftest ^:integration t-closed-conn-mgr-for-empty-body
+  (run-server)
+  (let [shutdown? (atom false)
+        cm (proxy [BasicClientConnectionManager] []
+             (shutdown []
+               (reset! shutdown? true)))
+        response (core/request {:request-method :get :uri "/unmodified-resource"
+                             :server-port 18080 :scheme :http
+                             :server-name "localhost"
+                             :connection-manager cm })]
+    (is (nil? (:body response)) "response shouldn't have body")
+    (is (= 304 (:status response)))
+    (is @shutdown? "connection manager should be shut downed")))

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -51,6 +51,8 @@
     [:get "/redirect-to-get"]
     {:status 302
      :headers {"location" "http://localhost:18080/get"}}
+    [:get "/unmodified-resource"]
+    {:status 304}
     [:get "/transit-json"]
     {:status 200 :body (str "[\"^ \",\"~:eggplant\",[\"^ \",\"~:quux\","
                             "[\"~#set\",[1,3,2]]],\"~:baz\",\"~f7\","


### PR DESCRIPTION
clj-http doesn't close connection manager If server returns response without body. For example if server returns just code (like 304). In this case clj-http doesn't close socket in time which cause issues with sockets (many sockets hung in CLOSE_WAIT state because last FIN come after timeout or doesn't come at all).