### PR TITLE
cljs 0.0-3196 compat upgrade of tools.reader

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [slingshot "0.12.2"]
                  [cheshire "5.4.0"]
                  [crouton "0.1.2"]
-                 [org.clojure/tools.reader "0.8.16"]
+                 [org.clojure/tools.reader "0.9.0"]
                  [potemkin "0.3.13"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
                                   [org.clojure/tools.logging "0.3.1"]


### PR DESCRIPTION
`clj-http` uses `tools.reader 0.8.16`, but `ClojureScript 0.0-3196` needs at least `0.9.0`.

Issue in `ClojureScript 0.0-3196` with `tools.reader 0.8.16`:
```
clojure.lang.ArityException: Wrong number of args (2) passed to: reader/read
```

More in:
https://groups.google.com/forum/#!topic/clojure/pdZVL6gAPio

All tests pass with `tools.reader` upgrade.