### PR TITLE
Decode user info from URL if it is provided

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -134,7 +134,8 @@
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
      :uri (url-encode-illegal-characters (.getPath url-parsed))
-     :user-info (.getUserInfo url-parsed)
+     :user-info (if-let [user-info (.getUserInfo url-parsed)]
+                  (util/url-decode user-info))
      :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
 
 ;; Statuses for which clj-http will not throw an exception

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -461,6 +461,12 @@
   (is (= nil  (-> "https://example.com/" client/parse-url :server-port)))
   (is (= 8443 (-> "https://example.com:8443/" client/parse-url :server-port))))
 
+(deftest decode-credentials-from-url
+  (is (= "fred's diner:fred's password"
+         (-> "http://fred%27s%20diner:fred%27s%20password@example.com/foo"
+             client/parse-url
+             :user-info))))
+
 (deftest apply-on-form-params
   (testing "With form params"
     (let [param-client (client/wrap-form-params identity)


### PR DESCRIPTION
Summary:

Currently, proper URLs passed in with punctuation in the username or password fields come in URL encoded.  clj-http does not decode and submits the still-encoded fields to the server in the 'Basic' HTTP header, leading to logins not working when clj-http is used with valid URL-specified username/passwords that happen to contain punctuation.

Protocol details:

Encoding of basic authentication characters is strange.  Username and password are separated by ':' in both URLs and in the HTTP header.  

In the HTTP headers, the values are concatenated, separated by the colon character, and then Base64'ed.  They avoid ambiguity by making the colon character illegal in usernames.

;; RFC 2617
;;      user-pass   = userid ":" password
;;      userid      = *<TEXT excluding ":">
;;      password    = *TEXT

In URLs, the username and password are separately URL encoded and then separated by the colon character:

;; RFC 2396
; ;userinfo      = *( unreserved | escaped |
;;                              ";" | ":" | "&" | "=" | "+" | "$" | "," )

This allows punctuation to be used in usernames and passwords, with the exception of usernames and passwords.

The java.net.URL class does not decode usernames and passwords automatically when you call .getUserInfo:

;; The URL class does not itself encode or decode any URL components
;; according to the escaping mechanism defined in RFC2396. It is the
;; responsibility of the caller to encode any fields, which need to be
;; escaped prior to calling URL, and also to decode any escaped
;; fields, that are returned from URL. 

http://docs.oracle.com/javase/7/docs/api/java/net/URL.html

As a result, I think the right thing to do is to decode what we get back from .getUserInfo and define the :user-info field as not being URL encoded, as the HTTP header expects.


