### PR TITLE
Preventing NPE on decode-body-headers when body is nil (e.g. HEAD request)

### DIFF
--- a/README.org
+++ b/README.org
@@ -387,6 +387,8 @@ from clj-http's dependencies without causing any problems like so:
                  [clj-http "0.6.0" :exclusions [crouton]]])
 #+END_SRC
 
+Note also that HEAD requests will not return a body, in which case this setting will have no effect.
+
 clj-http will automatically disable the =:decode-body-headers= option.
 
 ** Misc

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -635,12 +635,14 @@
         client (fn [req] {:body (.getBytes text)})
         new-client (client/wrap-additional-header-parsing client)
         resp (new-client {:decode-body-headers true})
-        resp2 (new-client {:decode-body-headers false})]
+        resp2 (new-client {:decode-body-headers false})
+        resp3 ((client/wrap-additional-header-parsing (fn [req] {:body nil})) {:decode-body-headers true})]
     (is (= {"content-type" "text/html; charset=Shift_JIS"
             "content-style-type" "text/css"
             "content-script-type" "text/javascript"}
            (:headers resp)))
-    (is (nil? (:headers resp2)))))
+    (is (nil? (:headers resp2)))
+    (is (nil? (:headers resp3)))))
 
 (deftest t-wrap-additional-header-parsing-html5
   (let [^String text (slurp (resource "header-html5-test.html"))


### PR DESCRIPTION
Also updated documentation to add the caveat that this option won't do anything if you use a HEAD request.