### PR TITLE
Only attempt to parse additional headers from body when content-type is text

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -492,7 +492,11 @@
   [client]
   (fn [req]
     (let [resp (client req)]
-      (if (and (opt req :decode-body-headers) crouton-enabled? (:body resp))
+      (if (and (opt req :decode-body-headers)
+               crouton-enabled?
+               (:body resp)
+               (let [content-type (get-in resp [:headers "content-type"])]
+                 (or (str/blank? content-type) (.startsWith content-type "text"))))
         (let [body-bytes (util/force-byte-array (:body resp))
               body-stream1 (java.io.ByteArrayInputStream. body-bytes)
               body-map (parse-html body-stream1)

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -637,13 +637,18 @@
         resp (new-client {:decode-body-headers true})
         resp2 (new-client {:decode-body-headers false})
         resp3 ((client/wrap-additional-header-parsing
-                (fn [req] {:body nil})) {:decode-body-headers true})]
+                (fn [req] {:body nil})) {:decode-body-headers true})
+        resp4 ((client/wrap-additional-header-parsing
+                (fn [req] {:headers {"content-type" "application/pdf"}
+                           :body (.getBytes text)}))
+               {:decode-body-headers true})]
     (is (= {"content-type" "text/html; charset=Shift_JIS"
             "content-style-type" "text/css"
             "content-script-type" "text/javascript"}
            (:headers resp)))
     (is (nil? (:headers resp2)))
-    (is (nil? (:headers resp3)))))
+    (is (nil? (:headers resp3)))
+    (is (= {"content-type" "application/pdf"} (:headers resp4)))))
 
 (deftest t-wrap-additional-header-parsing-html5
   (let [^String text (slurp (resource "header-html5-test.html"))


### PR DESCRIPTION
Hi,

Please also consider this pull request for decode-body-headers which restricts the attempt to the text mime type. I was encountering a stack overflow from Crouton when using this option while downloading a large (1.7mb PDF file).

I have left it so that if no content type is supplied it will also attempt to parse the body for headers - let me know if you agree with this or not.

Finally I was unsure about the case of "content-type" - it wasn't immediately obvious if I could rely on that being the key supplied in the headers, although there was other code that did the same - again, let me know if this needs changing.

Thanks!