### PR TITLE
Custom cookie validation

### DIFF
--- a/README.org
+++ b/README.org
@@ -170,13 +170,9 @@ Example requests:
                    "http.protocol.version" HttpVersion/HTTP_1_0
                    "http.useragent" "clj-http"}})
 
-;; Set your own cookie policy
+;; Do not validate cookies:
 (client/post "http://example.com"
-  {:client-params {:cookie-policy (fn [cookie origin] (your-validation cookie origin))}})
-
-;; Completely ignore cookies:
-(client/post "http://example.com"
-  {:client-params {:cookie-policy (constantly nil)}})
+  {:cookie-validation (fn [cookie origin])})
 
 ;; Need to contact a server with an untrusted SSL cert?
 (client/get "https://alioth.debian.org" {:insecure? true})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdakazan/clj-http "2.0.3-SNAPSHOT"
+(defproject lambdakazan/clj-http "2.0.3"
   :description "A Clojure HTTP library wrapping the Apache HttpComponents client."
   :url "https://github.com/dakrone/clj-http/"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdakazan/clj-http "2.0.1"
+(defproject lambdakazan/clj-http "2.0.2"
   :description "A Clojure HTTP library wrapping the Apache HttpComponents client."
   :url "https://github.com/dakrone/clj-http/"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-http "3.0.0-SNAPSHOT"
+(defproject lambdakazan/clj-http "2.0.1"
   :description "A Clojure HTTP library wrapping the Apache HttpComponents client."
   :url "https://github.com/dakrone/clj-http/"
   :license {:name "The MIT License"
@@ -30,6 +30,11 @@
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :aliases {"all" ["with-profile" "dev,1.5:dev,1.6:dev"]}
   :plugins [[codox "0.6.4"]]
+  :repositories [["snapshots" {:url "http://repo.lambdasoft.ru/artifactory/libs-snapshot-local"
+                               :sign-releases false
+                               :creds gpg}]
+                 ["releases" {:url "http://repo.lambdasoft.ru/artifactory/libs-release-local"
+                              :creds gpg}]]
   :test-selectors {:default  #(not (:integration %))
                    :integration :integration
                    :all (constantly true)})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdakazan/clj-http "2.0.2"
+(defproject lambdakazan/clj-http "2.0.3-SNAPSHOT"
   :description "A Clojure HTTP library wrapping the Apache HttpComponents client."
   :url "https://github.com/dakrone/clj-http/"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdakazan/clj-http "2.0.3"
+(defproject lambdakazan/clj-http "2.0.4-SNAPSHOT"
   :description "A Clojure HTTP library wrapping the Apache HttpComponents client."
   :url "https://github.com/dakrone/clj-http/"
   :license {:name "The MIT License"

--- a/src/clj_http/cookies.clj
+++ b/src/clj_http/cookies.clj
@@ -7,16 +7,24 @@
            (org.apache.http.params BasicHttpParams)
            (org.apache.http.impl.cookie BasicClientCookie2)
            (org.apache.http.impl.cookie BrowserCompatSpecFactory)
+           (org.apache.http.impl.cookie DefaultCookieSpec)
            (org.apache.http.message BasicHeader)
            org.apache.http.client.CookieStore
            (org.apache.http.impl.client BasicCookieStore)
            (org.apache.http Header)
            (org.apache.http.protocol BasicHttpContext)))
 
-(defn cookie-spec ^CookieSpec []
+(defn default-cookie-spec ^CookieSpec []
   (.create
    (BrowserCompatSpecFactory.)
    (BasicHttpContext.)))
+
+(defn cookie-spec ^CookieSpec
+  [validate-fn]
+  (if (nil? validate-fn)
+    (default-cookie-spec)
+    (proxy [DefaultCookieSpec] []
+      (validate [cookie origin] (validate-fn cookie origin)))))
 
 (defn compact-map
   "Removes all map entries where value is nil."
@@ -63,12 +71,12 @@
 
 (defn decode-cookie
   "Decode the Set-Cookie string into a cookie seq."
-  [set-cookie-str]
+  [cookie-spec set-cookie-str]
   (if-not (blank? set-cookie-str)
     ;; I just want to parse a cookie without providing origin. How?
     (let [domain (lower-case (str (gensym)))
           origin (CookieOrigin. domain 80 "/" false)
-          [cookie-name cookie-content] (-> (cookie-spec)
+          [cookie-name cookie-content] (-> cookie-spec
                                            (.parse (BasicHeader.
                                                     "set-cookie"
                                                     set-cookie-str)
@@ -81,23 +89,23 @@
 
 (defn decode-cookies
   "Converts a cookie string or seq of strings into a cookie map."
-  [cookies]
+  [cookie-spec cookies]
   (reduce #(assoc %1 (first %2) (second %2)) {}
-          (map decode-cookie (if (sequential? cookies) cookies [cookies]))))
+          (map #(decode-cookie cookie-spec %) (if (sequential? cookies) cookies [cookies]))))
 
 (defn decode-cookie-header
   "Decode the Set-Cookie header into the cookies key."
-  [response]
+  [cookie-spec response]
   (if-let [cookies (get (:headers response) "set-cookie")]
     (assoc response
-           :cookies (decode-cookies cookies)
+           :cookies (decode-cookies cookie-spec cookies)
            :headers (dissoc (:headers response) "set-cookie"))
     response))
 
 (defn encode-cookie
   "Encode the cookie into a string used by the Cookie header."
   [cookie]
-  (when-let [header (-> (cookie-spec)
+  (when-let [header (-> (default-cookie-spec)
                         (.formatCookies [(to-basic-client-cookie cookie)])
                         first)]
     (.getValue ^Header header)))
@@ -121,10 +129,12 @@
   request."
   [client]
   (fn [request]
-    (let [response (client (encode-cookie-header request))]
+    (let [cookie-validation (:cookie-validation request)
+          cookie-spec (cookie-spec cookie-validation)
+          response (client (encode-cookie-header request))]
       (if (= false (opt request :decode-cookies))
         response
-        (decode-cookie-header response)))))
+        (decode-cookie-header cookie-spec response)))))
 
 (defn cookie-store
   "Returns a new, empty instance of the default implementation of the

--- a/src/clj_http/cookies.clj
+++ b/src/clj_http/cookies.clj
@@ -3,7 +3,8 @@
   (:require [clj-http.util :refer [opt]]
             [clojure.string :refer [blank? join lower-case]])
   (:import (org.apache.http.client.params ClientPNames CookiePolicy)
-           (org.apache.http.cookie ClientCookie CookieOrigin CookieSpec)
+           (org.apache.http.cookie ClientCookie CookieOrigin
+                                   CookieSpec CookieSpecProvider)
            (org.apache.http.params BasicHttpParams)
            (org.apache.http.impl.cookie BasicClientCookie2)
            (org.apache.http.impl.cookie BrowserCompatSpecFactory)
@@ -24,7 +25,13 @@
   (if (nil? validate-fn)
     (default-cookie-spec)
     (proxy [DefaultCookieSpec] []
+      (match [cookie origin] true)
       (validate [cookie origin] (validate-fn cookie origin)))))
+
+(defn cookie-spec-provider ^CookieSpecProvider
+  [validate-fn]
+  (proxy [Object CookieSpecProvider] []
+    (create [context] (cookie-spec validate-fn))))
 
 (defn compact-map
   "Removes all map entries where value is nil."


### PR DESCRIPTION
It seems that cookie-policy doesn't work and tests were removed.
I'm not very familiar with Apache http-components, so this solution can be not very good, please tell me, I will try to fix it.

This PR adds a new key, `:cookie-validation`, into the request. If this key is associated with a function, it is used as a `validate` method in proxy class extending `DefaultCookieSpec`. This proxy class is used instead of `BasicCookieSpec` which is returned by `cookie-spec` function