### PR TITLE
Added support for multipart body of type org.apache.http.entity.mime.content.ContentBody

### DIFF
--- a/README.org
+++ b/README.org
@@ -247,7 +247,7 @@ content encodings.
                                               {:name "file" :content (clojure.java.io/file "pic.jpg")}]})
 
 ;; Multipart :content values can be one of the following:
-;; String, InputStream, File, or a byte-array
+;; String, InputStream, File, a byte-array, or an instance of org.apache.http.entity.mime.content.ContentBody
 ;; Some Multipart bodies can also support more keys (like :encoding
 ;; and :mime-type), check src/clj-http/multipart.clj to see all flags
 

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -4,7 +4,8 @@
            (java.nio.charset Charset)
            (org.apache.http.entity ContentType)
            (org.apache.http.entity.mime MultipartEntity)
-           (org.apache.http.entity.mime.content ByteArrayBody
+           (org.apache.http.entity.mime.content ContentBody
+                                                ByteArrayBody
                                                 FileBody
                                                 InputStreamBody
                                                 StringBody)))
@@ -97,11 +98,14 @@
 (defn make-multipart-body
   "Create a body object from the given map, dispatching on the type
   of its content. Requires the content to be of type File, InputStream,
-  ByteArray, or String."
+  ByteArray, String, or instance of org.apache.http.entity.mime.content.ContentBody."
   [multipart]
   (let [klass (type (:content multipart))]
     ;; TODO: replace with multimethod? actually helpful?
     (cond
+      (isa? klass ContentBody)
+      (:content multipart)
+
       (isa? klass File)
       (make-file-body multipart)
 


### PR DESCRIPTION
I need to supply multipart content as custom implementation of `org.apache.http.entity.mime.content.ContentBody` interface.

My fix would allow to use instances of `ContentBody` as multipart content and indirectly support any type of the content by wrapping it into a custom implementation of `ContentBody` that knows how to write that content into `OutputStream`.