### PR TITLE
Refactored multipart/make-multipart-body into multimethod.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ aws.clj
 docs/*
 doc
 http.log
+
+# Intellij Idea
+/*.iml
+/.idea

--- a/README.org
+++ b/README.org
@@ -247,7 +247,7 @@ content encodings.
                                               {:name "file" :content (clojure.java.io/file "pic.jpg")}]})
 
 ;; Multipart :content values can be one of the following:
-;; String, InputStream, File, or a byte-array
+;; String, InputStream, File, a byte-array, or an instance of org.apache.http.entity.mime.content.ContentBody
 ;; Some Multipart bodies can also support more keys (like :encoding
 ;; and :mime-type), check src/clj-http/multipart.clj to see all flags
 

--- a/test/clj_http/test/multipart.clj
+++ b/test/clj_http/test/multipart.clj
@@ -1,44 +1,163 @@
 (ns clj-http.test.multipart
   (:require [clj-http.multipart :refer :all]
             [clojure.test :refer :all])
-  (:import (java.io File)
-           (org.apache.http.entity.mime.content FileBody)))
+  (:import (java.io File ByteArrayOutputStream ByteArrayInputStream)
+           (org.apache.http.entity.mime.content FileBody StringBody ContentBody ByteArrayBody InputStreamBody)
+           (java.nio.charset Charset)))
 
-(deftest test-make-file-body
-  (testing "no content throws exception"
-    (is (thrown? Exception (make-file-body {}))))
+(defn body-str [^StringBody body]
+  (-> body .getReader slurp))
 
-  (testing "can create FileBody with content only"
-    (let [testfile (File. "testfile")
-          file-body (make-file-body {:content (File. "testfile")})]
-      (is (= (.getFile ^FileBody file-body) testfile))))
+(defn body-bytes [^ContentBody body]
+  (let [buf (ByteArrayOutputStream.)]
+    (.writeTo body buf)
+    (.toByteArray buf)))
 
-  (testing "can create FileBody with content and mime-type"
-    (let [testfile (File. "testfile")
-          file-body (make-file-body {:content (File. "testfile")
-                                     :mime-type "application/octet-stream"})]
-      (is (= (.getFile ^FileBody file-body) testfile))))
+(defn body-charset [^ContentBody body]
+  (-> body .getContentType .getCharset))
 
-  (testing "can create FileBody with content and mime-type and name"
-    (let [testfile (File. "testfile")
-          file-body (make-file-body {:content (File. "testfile")
-                                     :mime-type "application/octet-stream"
-                                     :name "testname"})]
-      (is (= (.getFile ^FileBody file-body) testfile))
-      (is (= (.getFilename ^FileBody file-body) "testname"))))
+(defn body-mime-type [^ContentBody body]
+  (-> body .getContentType .getMimeType))
 
-  (testing "can create FileBody with content and mime-type and encoding"
-    (let [testfile (File. "testfile")
-          file-body (make-file-body {:content (File. "testfile")
-                                     :mime-type "application/octet-stream"
-                                     :encoding "utf-8"})]
-      (is (= (.getFile ^FileBody file-body) testfile))))
+(defn make-input-stream [& bytes]
+  (ByteArrayInputStream. (byte-array bytes)))
 
-  (testing "can create FileBody with content, mime-type, encoding, and name"
-    (let [testfile (File. "testfile")
-          file-body (make-file-body {:content (File. "testfile")
-                                     :mime-type "application/octet-stream"
-                                     :encoding "utf-8"
-                                     :name "testname"})]
-      (is (= (.getFile ^FileBody file-body) testfile))
-      (is (= (.getFilename ^FileBody file-body) "testname")))))
+(deftest test-multipart-body
+  (testing "nil content throws exception"
+    (is (thrown-with-msg? Exception #"Multipart content cannot be nil"
+                          (make-multipart-body {:content nil}))))
+
+  (testing "unsupported content type throws exception"
+    (is (thrown-with-msg? Exception #"Unsupported type for multipart content: class java.lang.Object"
+                          (make-multipart-body {:content (Object.)}))))
+
+  (testing "ContentBody content direct usage"
+    (let [contentBody (StringBody. "abc")]
+      (is (identical? contentBody (make-multipart-body {:content contentBody})))))
+
+  (testing "StringBody"
+
+    (testing "can create StringBody with content only"
+      (let [body (make-multipart-body {:content "abc"})]
+        (is (instance? StringBody body))
+        (is (= "abc" (body-str body)))))
+
+    (testing "can create StringBody with content and encoding"
+      (let [body (make-multipart-body {:content "abc" :encoding "ascii"})]
+        (is (instance? StringBody body))
+        (is (= "abc" (body-str body)))
+        (is (= (Charset/forName "ascii") (body-charset body)))))
+
+    (testing "can create StringBody with content and mime-type and encoding"
+      (let [body (make-multipart-body {:content "abc" :mime-type "stream-body" :encoding "ascii"})]
+        (is (instance? StringBody body))
+        (is (= "abc" (body-str body)))
+        (is (= (Charset/forName "ascii") (body-charset body)))
+        (is (= "stream-body" (body-mime-type body))))))
+
+  (testing "ByteArrayBody"
+
+    (testing "exception thrown on missing name"
+      (is (thrown-with-msg? Exception #"Multipart byte array body must contain at least :content and :name"
+                            (make-multipart-body {:content (byte-array [0 1 2])}))))
+
+    (testing "can create ByteArrayBody with name only"
+      (let [body (make-multipart-body {:content (byte-array [0 1 2]) :name "testname"})]
+        (is (instance? ByteArrayBody body))
+        (is (= "testname" (.getFilename body)))
+        (is (= [0 1 2] (vec (body-bytes body))))))
+
+    (testing "can create ByteArrayBody with name and mime-type"
+      (let [body (make-multipart-body {:content   (byte-array [0 1 2])
+                                       :name      "testname"
+                                       :mime-type "byte-body"})]
+        (is (instance? ByteArrayBody body))
+        (is (= "testname" (.getFilename body)))
+        (is (= "byte-body" (body-mime-type body)))
+        (is (= [0 1 2] (vec (body-bytes body)))))))
+
+  (testing "InputStreamBody"
+
+    (testing "exception thrown on missing name"
+      (is (thrown-with-msg?
+            Exception
+            #"Multipart input stream body must contain at least :content and :name"
+            (make-multipart-body {:content (ByteArrayInputStream. (byte-array [0 1 2]))}))))
+
+    (testing "can create InputStreamBody with name and content"
+      (let [input-stream (make-input-stream 1 2 3)
+            body (make-multipart-body {:content input-stream
+                                       :name    "testname"})]
+        (is (instance? InputStreamBody body))
+        (is (= "testname" (.getFilename body)))
+        (is (identical? input-stream (.getInputStream body)))))
+
+    (testing "can create InputStreamBody with name, content and mime-type"
+      (let [input-stream (make-input-stream 1 2 3)
+            body (make-multipart-body {:content   input-stream
+                                       :name      "testname"
+                                       :mime-type "input-stream-body"})]
+        (is (instance? InputStreamBody body))
+        (is (= "testname" (.getFilename body)))
+        (is (= "input-stream-body" (body-mime-type body)))
+        (is (identical? input-stream (.getInputStream body)))))
+
+    (testing "can create input InputStreamBody name, content, mime-type and length"
+      (let [input-stream (make-input-stream 1 2 3)
+            body (make-multipart-body {:content   input-stream
+                                       :name      "testname"
+                                       :mime-type "input-stream-body"
+                                       :length    42})]
+        (is (instance? InputStreamBody body))
+        (is (= "testname" (.getFilename body)))
+        (is (= "input-stream-body" (body-mime-type body)))
+        (is (identical? input-stream (.getInputStream body)))
+        (is (= 42 (.getContentLength body))))))
+
+  (testing "FileBody"
+
+    (testing "can create FileBody with content only"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content test-file})]
+        (is (instance? FileBody body))
+        (is (= test-file (.getFile body)))))
+
+    (testing "can create FileBody with content and mime-type"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content   test-file
+                                       :mime-type "file-body"})]
+        (is (instance? FileBody body))
+        (is (= "file-body" (body-mime-type body)))
+        (is (= test-file (.getFile body)))))
+
+    (testing "can create FileBody with content, mime-type and name"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content   test-file
+                                       :mime-type "file-body"
+                                       :name      "testname"})]
+        (is (instance? FileBody body))
+        (is (= "file-body" (body-mime-type body)))
+        (is (= test-file (.getFile body)))
+        (is (= "testname" (.getFilename body)))))
+
+    (testing "can create FileBody with content and mime-type and encoding"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content   test-file
+                                       :mime-type "file-body"
+                                       :encoding  "ascii"})]
+        (is (instance? FileBody body))
+        (is (= "file-body" (body-mime-type body)))
+        (is (= (Charset/forName "ascii") (body-charset body)))
+        (is (= test-file (.getFile body)))))
+
+    (testing "can create FileBody with content, mime-type, encoding and name"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content   test-file
+                                       :mime-type "file-body"
+                                       :encoding  "ascii"
+                                       :name      "testname"})]
+        (is (instance? FileBody body))
+        (is (= "file-body" (body-mime-type body)))
+        (is (= (Charset/forName "ascii") (body-charset body)))
+        (is (= test-file (.getFile body) ))
+        (is (= "testname" (.getFilename body)))))))


### PR DESCRIPTION
This change will allow simple extension of multipart content conversions into `org.apache.http.entity.mime.content.ContentBody` implementations.

As a bonus all calls to deprecated constructors of `StringBody`, `FileBody` etc. were migrated to new ones and there are many more tests for `clj-http.multipart` namespace.

I have already opened another pull request #300 which provides very small fix which allows passing `ContentBody` directly as content. I would prefer incorporating multimethod implementation but the other PR will make my life easier too.

If this PR gets accepted I can prepare a verson for master branch too.