### PR TITLE
Use http-client 4.5 not deprecated methods

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -14,7 +14,7 @@
            (java.net URL UnknownHostException)
            (org.apache.http.entity BufferedHttpEntity ByteArrayEntity
                                    InputStreamEntity FileEntity StringEntity)
-           (org.apache.http.impl.conn PoolingClientConnectionManager))
+           (org.apache.http.impl.conn PoolingHttpClientConnectionManager))
   (:refer-clojure :exclude [get update]))
 
 ;; Cheshire is an optional dependency, so we check for it at compile time.
@@ -953,9 +953,9 @@
 
 (defmacro with-connection-pool
   "Macro to execute the body using a connection manager. Creates a
-  PoolingClientConnectionManager to use for all requests within the body of
-  the expression. An option map is allowed to set options for the connection
-  manager.
+  PoolingHttpClientConnectionManager to use for all requests within the
+  body of the expression. An option map is allowed to set options for the
+  connection manager.
 
   The following options are supported:
 
@@ -989,5 +989,5 @@
          ~@body
          (finally
            (.shutdown
-            ^PoolingClientConnectionManager
+            ^PoolingHttpClientConnectionManager
             conn/*connection-manager*))))))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -671,7 +671,7 @@
 
 (deftest ^:integration t-reusable-conn-mgrs
   (run-server)
-  (let [cm (conn/pooling-conn-mgr)
+  (let [cm (conn/make-reusable-conn-manager {:timeout 10 :insecure? false})
         resp1 (request {:uri "/redirect-to-get"
                         :method :get
                         :connection-manager cm})

--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -5,8 +5,11 @@
             [clojure.test :refer :all]
             [ring.adapter.jetty :as ring])
   (:import (java.security KeyStore)
-           (org.apache.http.conn.ssl SSLSocketFactory)
-           (org.apache.http.impl.conn BasicHttpClientConnectionManager)))
+           (org.apache.http.impl.conn BasicHttpClientConnectionManager)
+           (org.apache.http.conn.ssl SSLConnectionSocketFactory
+                                     DefaultHostnameVerifier
+                                     NoopHostnameVerifier
+                                     TrustStrategy)))
 
 (def client-ks "test-resources/client-keystore")
 (def client-ks-pass "keykey")
@@ -40,8 +43,8 @@
   (let [sr (conn-mgr/get-keystore-scheme-registry
             {:keystore client-ks :keystore-pass client-ks-pass
              :trust-store client-ks :trust-store-pass client-ks-pass})
-        socket-factory (.getSchemeSocketFactory (.get sr "https"))]
-    (is (instance? SSLSocketFactory socket-factory))))
+        socket-factory (.lookup sr "https")]
+    (is (instance? SSLConnectionSocketFactory socket-factory))))
 
 (deftest ^:integration ssl-client-cert-get
   (let [server (ring/run-jetty secure-handler


### PR DESCRIPTION
Hi,
I moved some stuff to http-client 4.5. There is still a few things to be done and tested. Almost all currently existing tests are ok though. I am not sure what should be done with the redirects features. The current redirect clj-http wrapper overlaps with the http-client redirects configuration. 