### PR TITLE
Separate Transit reader and writer options

### DIFF
--- a/README.org
+++ b/README.org
@@ -232,12 +232,16 @@ content encodings.
 ;; Send form params as a Transit encoded JSON body (POST or PUT) with options
 (client/post "http://site.com" {:form-params {:foo "bar"}
                                 :content-type :transit+json
-                                :transit-opts {:handlers {}}})
+                                :transit-opts
+                                {:encode {:handlers {}}
+                                 :decode {:handlers {}}}})
 
 ;; Send form params as a Transit encoded MessagePack body (POST or PUT) with options
 (client/post "http://site.com" {:form-params {:foo "bar"}
                                 :content-type :transit+msgpack
-                                :transit-opts {:handlers {}}})
+                                :transit-opts
+                                {:encode {:handlers {}}
+                                 :decode {:handlers {}}}})
 
 ;; Multipart form uploads/posts
 ;; takes a vector of maps, to preserve the order of entities, :name

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -72,7 +72,7 @@
   {:pre [transit-enabled?]}
   (let [reader (ns-resolve 'cognitect.transit 'reader)
         read (ns-resolve 'cognitect.transit 'read)]
-    (read (reader in type opts))))
+    (read (reader in type (:decode opts)))))
 
 (defn ^:dynamic transit-encode
   "Resolve and apply Transit's JSON/MessagePack encoding."
@@ -81,7 +81,7 @@
   (let [output (ByteArrayOutputStream.)
         writer (ns-resolve 'cognitect.transit 'writer)
         write (ns-resolve 'cognitect.transit 'write)]
-    (write (writer output type opts) out)
+    (write (writer output type (:encode opts)) out)
     (.toByteArray output)))
 
 (defn ^:dynamic json-encode


### PR DESCRIPTION
As mentioned in issue #292, the Transit reader and writer require
different options. At the moment `:transit-opts` is passed to both
reader and writer, which means you can either specify read handlers or
write handlers, but not both. Transit will complain if `:handlers` is a
mix of read and write handlers.

This patch splits up `:transit-opts` into a `:encode` and `:decode`
section. The options in `:encode` will be passed to the writer, the
options in `:decode` to the reader.