### PR TITLE
support HttpRequestInterceptor

### DIFF
--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -12,8 +12,8 @@
            (org.apache.http.message BasicHeader BasicHeaderIterator)
            (org.apache.http.client.methods HttpPost)
            (org.apache.http.client.params CookiePolicy ClientPNames)
-           (org.apache.http HttpResponse HttpConnection HttpInetConnection
-                            HttpVersion)
+           (org.apache.http HttpRequest HttpResponse HttpConnection 
+                            HttpInetConnection HttpVersion)
            (org.apache.http.protocol HttpContext ExecutionContext)
            (org.apache.http.impl.client DefaultHttpClient)
            (org.apache.http.client.params ClientPNames)
@@ -421,6 +421,19 @@
                                                :form-params params})]
     (is (= 200 (:status resp)))
     (is (= (json/encode params) (:body resp)))))
+
+(deftest ^:integration t-request-interceptor
+  (run-server)
+  (let [req-ctx (atom [])
+        {:keys [status trace-redirects] :as resp}
+        (client/get
+         (localhost "/get")
+         {:request-interceptor
+          (fn [^HttpRequest req ^HttpContext ctx]
+            (reset! req-ctx {:method (.getMethod req) :uri (.getURI req)}))})]
+    (is (= 200 status))
+    (is (= "GET" (:method @req-ctx)))
+    (is (= "/get" (.getPath (:uri @req-ctx))))))
 
 (deftest ^:integration t-response-interceptor
   (run-server)


### PR DESCRIPTION
Similar to #310 but for master branch. Adds interceptor to `HttpClientBuilder` instead of `DefaultHttpClient`