### PR TITLE
Fix issue #257

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -346,11 +346,12 @@
 (defn coerce-clojure-body
   [request {:keys [body] :as resp}]
   (let [^String charset (or (-> resp :content-type-params :charset) "UTF-8")
-        body (util/force-byte-array body)]
-    (if edn-enabled?
-      (assoc resp :body (parse-edn (String. ^"[B" body charset)))
-      (binding [*read-eval* false]
-        (assoc resp :body (read-string (String. ^"[B" body charset)))))))
+        body            (util/force-byte-array body)]
+    (assoc resp :body (cond
+                        (empty? body) nil
+                        edn-enabled? (parse-edn (String. ^"[B" body charset))
+                        :else (binding [*read-eval* false]
+                                (read-string (String. ^"[B" body charset)))))))
 
 (defn coerce-transit-body
   [{:keys [transit-opts] :as request} {:keys [body] :as resp} type]

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -565,8 +565,7 @@
   (run-server)
   (client/request {:method :get :url (localhost "/get") :headers {"foo" 2}}))
 
-;; Currently failing, see: https://github.com/dakrone/clj-http/issues/257
-;; (deftest ^:integration t-empty-response-coercion
-;;   (run-server)
-;;   (let [resp (client/get (localhost "/empty") {:as :clojure})]
-;;     (is (= (:body resp) ""))))
+(deftest ^:integration t-empty-response-coercion
+   (run-server)
+   (let [resp (client/get (localhost "/empty") {:as :clojure})]
+     (is (= (:body resp) nil))))


### PR DESCRIPTION
This commit checks if the body is empty during clojure coercion.
If it's empty, the body is set to nil. Previously, the test assumed
the body would return as an empty string but the expected behavior
per the convo in the issue is that nil should be returned.