### PR TITLE
Provide access to the status line in the response?

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -315,7 +315,8 @@
     (try
       (let [^CloseableHttpResponse response (.execute client http-req context)
             ^HttpEntity entity (.getEntity response)
-            status (.getStatusLine response)]
+            status (.getStatusLine response)
+            protocol-version (.getProtocolVersion status)]
         {:body (coerce-body-entity entity conn-mgr response)
          :headers (parse-headers
                    (.headerIterator response)
@@ -325,7 +326,7 @@
          :repeatable? (if (nil? entity) false (.isRepeatable entity))
          :streaming? (if (nil? entity) false (.isStreaming entity))
          :status (.getStatusCode status)
-         :protocol-version (.getProtocolVersion status)
+         :protocol-version  {:name (.getProtocol protocol-version) :major (.getMajor protocol-version) :minor (.getMinor protocol-version)}  
          :reason-phrase (.getReasonPhrase status)})
       (catch Throwable t
         (when-not (conn/reusable? conn-mgr)

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -324,7 +324,9 @@
          :chunked? (if (nil? entity) false (.isChunked entity))
          :repeatable? (if (nil? entity) false (.isRepeatable entity))
          :streaming? (if (nil? entity) false (.isStreaming entity))
-         :status (.getStatusCode status)})
+         :status (.getStatusCode status)
+         :protocol-version (.getProtocolVersion status)
+         :reason-phrase (.getReasonPhrase status)})
       (catch Throwable t
         (when-not (conn/reusable? conn-mgr)
           (.shutdown conn-mgr))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -836,3 +836,13 @@
     (is (= 200 (:status resp)))
     (is (= "close" (get-in resp [:headers "connection"])))
     (is (= "propfindbody" (:body resp)))))
+
+(deftest ^:integration status-line-parsing
+  (run-server)
+  (let [resp (request {:uri "/get" :method :get})
+        protocol-version (:protocol-version resp)]
+    (is (= 200 (:status resp)))
+    (is (= "HTTP" (:name protocol-version)))
+    (is (= 1 (:major protocol-version)))
+    (is (= 1 (:minor protocol-version)))
+    (is (= "OK" (:reason-phrase resp)))))


### PR DESCRIPTION
Hi,

Loving the library it really makes working with http client simple! 

I found myself wanting to print out the status line for the response and saw that you only map the status code from the underlying http client response. 

Perhaps theres a reason you didn't add that, but I think it would be useful to get it as it comes with the http client response anyway. 

I've forked and added the code so thought I'd send you a pull request and see if you think its worth adding?

Thanks

Jim