### PR TITLE
Add ring like async HTTP request support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :exclusions [org.clojure/clojure]
   :dependencies [[org.apache.httpcomponents/httpcore "4.4.5"]
                  [org.apache.httpcomponents/httpclient "4.5.2"]
+                 [org.apache.httpcomponents/httpasyncclient "4.1.2"]
                  [org.apache.httpcomponents/httpmime "4.5.2"]
                  [commons-codec "1.10"]
                  [commons-io "2.5"]

--- a/src/clj_http/headers.clj
+++ b/src/clj_http/headers.clj
@@ -131,13 +131,19 @@
   (into (HeaderMap. {} nil)
         (apply array-map keyvals)))
 
+(defn- header-map-request
+  [req]
+  (let [req-headers (:headers req)]
+    (if req-headers
+      (-> req (assoc :headers (into (header-map) req-headers)
+                     :use-header-maps-in-response? true))
+      req)))
+
 (defn wrap-header-map
   "Middleware that converts headers from a map into a header-map."
   [client]
-  (fn [req]
-    (let [req-headers (:headers req)
-          req (if req-headers
-                (-> req (assoc :headers (into (header-map) req-headers)
-                               :use-header-maps-in-response? true))
-                req)]
-      (client req))))
+  (fn
+    ([req]
+     (client (header-map-request req)))
+    ([req respond raise]
+     (client (header-map-request req) respond raise))))


### PR DESCRIPTION
I added a ring like CPS async HTTP client support. The request can simply like

`(client/get "https://www.google.com" {:async? true} respond raise)`

`respond` can simply be a promise or more complex function, `raise` is the same.
The exception which throw by `wrap-exceptions` now  is passed to `raise` handler.

There is also a `with-async-connection-pool` macro, which can make all async request in this context using one `PoolingNHttpClientConnectionManager` and shutdown the conn-mgr when all request is finished.

Also provide a helper function `reuse-pool` which used in `respond` callback, it take a new request options map and a response then return a new options map that can let the client reuse the connection pool. The usage of connection pool can see `t-with-async-pool` and `t-reuse-async-pool` in `client-test`.

I think async HTTP request is important in the future and ring also added async support, I tried to add a ring like async request support.