### PR TITLE
Support three different multi-param syntaxes

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -756,25 +756,20 @@
                          :body (coerce-form-params req))))
       (client req))))
 
-(defn- nest-kv
-  [kv]
-  (if (and (vector? kv)
-           (or (map? (second kv))
-               (vector? (second kv))))
-    (let [[fk m] kv]
-      (reduce-kv (fn [m sk v]
-                   (assoc m
-                     (str (name fk)
-                          \[ (if (integer? sk) sk (name sk)) \])
-                     v))
-                 {}
-                 m))
-    kv))
-
 (defn- nest-params
   [request param-key]
   (if-let [params (request param-key)]
-    (assoc request param-key (prewalk nest-kv params))
+    (assoc request param-key (prewalk
+                              #(if (and (vector? %) (map? (second %)))
+                                 (let [[fk m] %]
+                                   (reduce
+                                    (fn [m [sk v]]
+                                      (assoc m (str (name fk)
+                                                    \[ (name sk) \]) v))
+                                    {}
+                                    m))
+                                 %)
+                              params))
     request))
 
 (defn wrap-nested-params

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -616,15 +616,10 @@
     (are [in out] (is-applied client/wrap-nested-params
                               {:query-params in :form-params in}
                               {:query-params out :form-params out})
-      {"x" ["0" "1"]} {"x[0]" "0" "x[1]" "1"}
-
-      {"x" [{"y" "a" "z" "b"} {"w" "c"}]}
-      {"x[0][y]" "a" "x[0][z]" "b" "x[1][w]" "c"}
-
-      {"foo" "bar"} {"foo" "bar"}
-      {"x" {"y" "z"}} {"x[y]" "z"}
-      {"a" {"b" {"c" "d"}}} {"a[b][c]" "d"}
-      {"a" "b", "c" "d"} {"a" "b", "c" "d"}))
+         {"foo" "bar"} {"foo" "bar"}
+         {"x" {"y" "z"}} {"x[y]" "z"}
+         {"a" {"b" {"c" "d"}}} {"a[b][c]" "d"}
+         {"a" "b", "c" "d"} {"a" "b", "c" "d"}))
 
   (testing "not creating empty param maps"
     (is-applied client/wrap-query-params {} {})))

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -99,7 +99,9 @@
     [:propfind "/propfind"]
     {:status 200 :body "propfind"}
     [:propfind "/propfind-with-body"]
-    {:status 200 :body (:body req)}))
+    {:status 200 :body (:body req)}
+    [:get "/query-string"]
+    {:status 200 :body (:query-string req)}))
 
 (defn run-server
   []


### PR DESCRIPTION
As discussed [here](https://github.com/dakrone/clj-http/commit/7ec10113776655d04234edcb3238a5a50943980a#commitcomment-18959911)

When params have multiple values, you can now choose the style used to build a param string. There are three styles available:

by default, a repeating param:

    :a [1 2 3] => "a=1&a=2&a=3"

with `:multi-param-style :array`, a repeating param with array suffix (PHP-style):

    :a [1 2 3] => "a[]=1&a[]=2&a[]=3"

with `:multi-param-style :indexed`, a repeating param with array suffix and index (Rails-style):

    :a [1 2 3] => "a[0]=1&a[1]=2&a[2]=3"

/cc @dakrone @clyfe @ygliuvt @joegallo 

Happy to submit another PR for the 2.x branch.