### PR TITLE
Support three different multi-param syntaxes (2.x)

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -617,28 +617,34 @@
      (second found))
    "UTF-8"))
 
-(defn generate-query-string-with-encoding [params encoding]
+(defn- multi-param-suffix [index multi-param-style]
+  (case multi-param-style
+    :indexed (str "[" index "]")
+    :array "[]"
+    ""))
+
+(defn generate-query-string-with-encoding [params encoding multi-param-style]
   (str/join "&"
             (mapcat (fn [[k v]]
                       (if (sequential? v)
-                        (map #(str (util/url-encode (name %1) encoding)
-                                   "="
-                                   (util/url-encode (str %2) encoding))
-                             (repeat k) v)
+                        (map-indexed #(str (util/url-encode (name k) encoding)
+                                           (multi-param-suffix %1 multi-param-style)
+                                           "="
+                                           (util/url-encode (str %2) encoding)) v)
                         [(str (util/url-encode (name k) encoding)
                               "="
                               (util/url-encode (str v) encoding))]))
                     params)))
 
-(defn generate-query-string [params & [content-type]]
+(defn generate-query-string [params & [content-type multi-param-style]]
   (let [encoding (detect-charset content-type)]
-    (generate-query-string-with-encoding params encoding)))
+    (generate-query-string-with-encoding params encoding multi-param-style)))
 
 (defn wrap-query-params
   "Middleware converting the :query-params option to a querystring on
   the request."
   [client]
-  (fn [{:keys [query-params content-type]
+  (fn [{:keys [query-params content-type multi-param-style]
        :or {content-type :x-www-form-urlencoded}
        :as req}]
     (if query-params
@@ -650,7 +656,8 @@
                                  new-query-string))
                              (generate-query-string
                               query-params
-                              (content-type-value content-type)))))
+                              (content-type-value content-type)
+                              multi-param-style))))
       (client req))))
 
 (defn basic-auth-value [basic-auth]
@@ -736,11 +743,13 @@
                      :json-opts json-opts})))
   (json-encode form-params json-opts))
 
-(defmethod coerce-form-params :default [{:keys [content-type form-params
+(defmethod coerce-form-params :default [{:keys [content-type
+                                                multi-param-style
+                                                form-params
                                                 form-param-encoding]}]
   (if form-param-encoding
-    (generate-query-string-with-encoding form-params form-param-encoding)
-    (generate-query-string form-params (content-type-value content-type))))
+    (generate-query-string-with-encoding form-params form-param-encoding multi-param-style)
+    (generate-query-string form-params (content-type-value content-type) multi-param-style)))
 
 (defn wrap-form-params
   "Middleware wrapping the submission or form parameters."

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -616,8 +616,6 @@
     (are [in out] (is-applied client/wrap-nested-params
                               {:query-params in :form-params in}
                               {:query-params out :form-params out})
-         {"x" ["0" "1"]} {"x[0]" "0" "x[1]" "1"}
-         {"x" [{"y" "a" "z" "b"} {"w" "c"}]} {"x[0][y]" "a" "x[0][z]" "b" "x[1][w]" "c"}
          {"foo" "bar"} {"foo" "bar"}
          {"x" {"y" "z"}} {"x[y]" "z"}
          {"a" {"b" {"c" "d"}}} {"a[b][c]" "d"}

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -95,7 +95,9 @@
     [:patch "/patch"]
     {:status 200 :body "patch"}
     [:get "/headers"]
-    {:status 200 :body (json/encode (:headers req))}))
+    {:status 200 :body (json/encode (:headers req))}
+    [:get "/query-string"]
+    {:status 200 :body (:query-string req)}))
 
 (defn run-server
   []


### PR DESCRIPTION
As discussed [here](https://github.com/dakrone/clj-http/commit/7ec10113776655d04234edcb3238a5a50943980a#commitcomment-18959911)

When params have multiple values, you can now choose the style used to build a param string. There are three styles available:

by default, a repeating param:

    :a [1 2 3] => "a=1&a=2&a=3"

with `:multi-param-style :array`, a repeating param with array suffix (PHP-style):

    :a [1 2 3] => "a[]=1&a[]=2&a[]=3"

with `:multi-param-style :indexed`, a repeating param with array suffix and index (Rails-style):

    :a [1 2 3] => "a[0]=1&a[1]=2&a[2]=3"

/cc @joshuaknox

This PR for the 2.x branch is logically identical to #332.