### PR TITLE
Use with-open to ensure closing jetty

### DIFF
--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -103,10 +103,19 @@
     [:get "/query-string"]
     {:status 200 :body (:query-string req)}))
 
+
+(defprotocol Closable
+  (close [_]))
+
+(extend-type org.eclipse.jetty.server.Server Closable
+             (close [s] (.stop s)))
+
 (defn run-server
-  []
-  (defonce server
-    (ring/run-jetty #'handler {:port 18080 :join? false})))
+  ([] (run-server #'handler {:port 18080 :join? false}))
+  ([config] (run-server #'handler config))
+  ([h config] (let [server (ring/run-jetty h config)]
+                  (reify Closable
+                    (close [this] (.stop server))))))
 
 (defn localhost [path]
   (str "http://localhost:18080" path))
@@ -123,139 +132,136 @@
   (slurp (:body req)))
 
 (deftest ^:integration makes-get-request
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get"})]
-    (is (= 200 (:status resp)))
-    (is (= "get" (slurp-body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :get :uri "/get"})]
+      (is (= 200 (:status resp)))
+      (is (= "get" (slurp-body resp))))))
 
 (deftest ^:integration makes-head-request
-  (run-server)
-  (let [resp (request {:request-method :head :uri "/head"})]
-    (is (= 200 (:status resp)))
-    (is (nil? (:body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :head :uri "/head"})]
+      (is (= 200 (:status resp)))
+      (is (nil? (:body resp))))))
 
 (deftest ^:integration sets-content-type-with-charset
-  (run-server)
-  (let [resp (client/request {:scheme :http
-                              :server-name "localhost"
-                              :server-port 18080
-                              :request-method :get :uri "/content-type"
-                              :content-type "text/plain"
-                              :character-encoding "UTF-8"})]
-    (is (= "text/plain; charset=UTF-8" (:body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (client/request {:scheme :http
+                                :server-name "localhost"
+                                :server-port 18080
+                                :request-method :get :uri "/content-type"
+                                :content-type "text/plain"
+                                :character-encoding "UTF-8"})]
+      (is (= "text/plain; charset=UTF-8" (:body resp))))))
 
 (deftest ^:integration sets-content-type-without-charset
-  (run-server)
-  (let [resp (client/request {:scheme :http
-                              :server-name "localhost"
-                              :server-port 18080
-                              :request-method :get :uri "/content-type"
-                              :content-type "text/plain"})]
-    (is (= "text/plain" (:body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (client/request {:scheme :http
+                                :server-name "localhost"
+                                :server-port 18080
+                                :request-method :get :uri "/content-type"
+                                :content-type "text/plain"})]
+      (is (= "text/plain" (:body resp))))))
 
 (deftest ^:integration sets-arbitrary-headers
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/header"
-                       :headers {"x-my-header" "header-val"}})]
-    (is (= "header-val" (slurp-body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :get :uri "/header"
+                         :headers {"x-my-header" "header-val"}})]
+      (is (= "header-val" (slurp-body resp))))))
 
 (deftest ^:integration sends-and-returns-byte-array-body
-  (run-server)
-  (let [resp (request {:request-method :post :uri "/post"
-                       :body (util/utf8-bytes "contents")})]
-    (is (= 200 (:status resp)))
-    (is (= "contents" (slurp-body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :post :uri "/post"
+                         :body (util/utf8-bytes "contents")})]
+      (is (= 200 (:status resp)))
+      (is (= "contents" (slurp-body resp))))))
 
 (deftest ^:integration returns-arbitrary-headers
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get"})]
-    (is (string? (get-in resp [:headers "date"])))
-    (is (nil? (get-in resp [:headers "Date"])))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :get :uri "/get"})]
+      (is (string? (get-in resp [:headers "date"])))
+      (is (nil? (get-in resp [:headers "Date"]))))))
 
 (deftest ^:integration returns-status-on-exceptional-responses
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/error"})]
-    (is (= 500 (:status resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :get :uri "/error"})]
+      (is (= 500 (:status resp))))))
 
 (deftest ^:integration sets-socket-timeout
-  (run-server)
-  (try
-    (is (thrown? SocketTimeoutException
-                 (client/request {:scheme :http
-                                  :server-name "localhost"
-                                  :server-port 18080
-                                  :request-method :get :uri "/timeout"
-                                  :socket-timeout 1})))))
+  (with-open [s (run-server)]
+    (try
+      (is (thrown? SocketTimeoutException
+                   (client/request {:scheme :http
+                                    :server-name "localhost"
+                                    :server-port 18080
+                                    :request-method :get :uri "/timeout"
+                                    :socket-timeout 1}))))))
 
 (deftest ^:integration delete-with-body
-  (run-server)
-  (let [resp (request {:request-method :delete :uri "/delete-with-body"
-                       :body (.getBytes "foo bar")})]
-    (is (= 200 (:status resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :delete :uri "/delete-with-body"
+                         :body (.getBytes "foo bar")})]
+      (is (= 200 (:status resp))))))
 
 (deftest ^:integration self-signed-ssl-get
-  (let [server (ring/run-jetty handler
-                               {:port 8081 :ssl-port 18082
-                                :ssl? true
-                                :join? false
-                                :keystore "test-resources/keystore"
-                                :key-password "keykey"})]
-    (try
-      (is (thrown? SunCertPathBuilderException
-                   (client/request {:scheme :https
-                                    :server-name "localhost"
-                                    :server-port 18082
-                                    :request-method :get :uri "/get"})))
-      (let [resp (request {:request-method :get :uri "/get" :server-port 18082
-                           :scheme :https :insecure? true})]
-        (is (= 200 (:status resp)))
-        (is (= "get" (String. (util/force-byte-array (:body resp))))))
-      (finally
-        (.stop server)))))
+  (with-open [server (run-server
+                      {:port 18080 :ssl-port 18082
+                       :ssl? true
+                       :join? false
+                       :keystore "test-resources/keystore"
+                       :key-password "keykey"})]
+    (is (thrown? SunCertPathBuilderException
+                 (client/request {:scheme :https
+                                  :server-name "localhost"
+                                  :server-port 18082
+                                  :request-method :get :uri "/get"})))
+    (let [resp (request {:request-method :get :uri "/get" :server-port 18082
+                         :scheme :https :insecure? true})]
+      (is (= 200 (:status resp)))
+      (is (= "get" (String. (util/force-byte-array (:body resp))))))))
 
 (deftest ^:integration multipart-form-uploads
-  (run-server)
-  (let [bytes (util/utf8-bytes "byte-test")
-        stream (ByteArrayInputStream. bytes)
-        resp (request {:request-method :post :uri "/multipart"
-                       :multipart [{:name "a" :content "testFINDMEtest"
-                                    :encoding "UTF-8"
-                                    :mime-type "application/text"}
-                                   {:name "b" :content bytes
-                                    :mime-type "application/json"}
-                                   {:name "d"
-                                    :content (file "test-resources/keystore")
-                                    :encoding "UTF-8"
-                                    :mime-type "application/binary"}
-                                   {:name "c" :content stream
-                                    :mime-type "application/json"}
-                                   {:name "e" :part-name "eggplant"
-                                    :content "content"
-                                    :mime-type "application/text"}]})
-        resp-body (apply str (map #(try (char %) (catch Exception _ ""))
-                                  (util/force-byte-array (:body resp))))]
-    (is (= 200 (:status resp)))
-    (is (re-find #"testFINDMEtest" resp-body))
-    (is (re-find #"application/json" resp-body))
-    (is (re-find #"application/text" resp-body))
-    (is (re-find #"UTF-8" resp-body))
-    (is (re-find #"byte-test" resp-body))
-    (is (re-find #"name=\"c\"" resp-body))
-    (is (re-find #"name=\"d\"" resp-body))
-    (is (re-find #"name=\"eggplant\"" resp-body))
-    (is (re-find #"content" resp-body))))
+  (with-open [s (run-server)]
+    (let [bytes (util/utf8-bytes "byte-test")
+          stream (ByteArrayInputStream. bytes)
+          resp (request {:request-method :post :uri "/multipart"
+                         :multipart [{:name "a" :content "testFINDMEtest"
+                                      :encoding "UTF-8"
+                                      :mime-type "application/text"}
+                                     {:name "b" :content bytes
+                                      :mime-type "application/json"}
+                                     {:name "d"
+                                      :content (file "test-resources/keystore")
+                                      :encoding "UTF-8"
+                                      :mime-type "application/binary"}
+                                     {:name "c" :content stream
+                                      :mime-type "application/json"}
+                                     {:name "e" :part-name "eggplant"
+                                      :content "content"
+                                      :mime-type "application/text"}]})
+          resp-body (apply str (map #(try (char %) (catch Exception _ ""))
+                                    (util/force-byte-array (:body resp))))]
+      (is (= 200 (:status resp)))
+      (is (re-find #"testFINDMEtest" resp-body))
+      (is (re-find #"application/json" resp-body))
+      (is (re-find #"application/text" resp-body))
+      (is (re-find #"UTF-8" resp-body))
+      (is (re-find #"byte-test" resp-body))
+      (is (re-find #"name=\"c\"" resp-body))
+      (is (re-find #"name=\"d\"" resp-body))
+      (is (re-find #"name=\"eggplant\"" resp-body))
+      (is (re-find #"content" resp-body)))))
 
 (deftest ^:integration multipart-inputstream-length
-  (run-server)
-  (let [bytes (util/utf8-bytes "byte-test")
-        stream (ByteArrayInputStream. bytes)
-        resp (request {:request-method :post :uri "/multipart"
-                       :multipart [{:name "c" :content stream :length 9
-                                    :mime-type "application/json"}]})
-        resp-body (apply str (map #(try (char %) (catch Exception _ ""))
-                                  (util/force-byte-array (:body resp))))]
-    (is (= 200 (:status resp)))
-    (is (re-find #"byte-test" resp-body))))
+  (with-open [s (run-server)]
+    (let [bytes (util/utf8-bytes "byte-test")
+          stream (ByteArrayInputStream. bytes)
+          resp (request {:request-method :post :uri "/multipart"
+                         :multipart [{:name "c" :content stream :length 9
+                                      :mime-type "application/json"}]})
+          resp-body (apply str (map #(try (char %) (catch Exception _ ""))
+                                    (util/force-byte-array (:body resp))))]
+      (is (= 200 (:status resp)))
+      (is (re-find #"byte-test" resp-body)))))
 
 (deftest parse-headers
   (are [headers expected]
@@ -277,117 +283,117 @@
     {"set-cookie" ["one" "two"] "server" "some-server"}))
 
 (deftest ^:integration t-streaming-response
-  (run-server)
-  (let [stream (:body (request {:request-method :get :uri "/get" :as :stream}))
-        body (slurp stream)]
-    (is (= "get" body))))
+  (with-open [s (run-server)]
+    (let [stream (:body (request {:request-method :get :uri "/get" :as :stream}))
+          body (slurp stream)]
+      (is (= "get" body)))))
 
 
 (deftest ^:integration throw-on-too-many-redirects
-  (run-server)
-  (let [resp (client/get (localhost "/redirect")
-                         {:max-redirects 2 :throw-exceptions false
-                          :redirect-strategy :none
-                          :allow-circular-redirects true})]
-    (is (= 302 (:status resp)))
-    #_(is (= (apply vector (repeat 3 "http://localhost:18080/redirect"))
-             (:trace-redirects resp))))
-  (is (thrown-with-msg? Exception #"Maximum redirects \(2\) exceeded"
-                        (client/get (localhost "/redirect")
-                                    {:max-redirects 2
-                                     :throw-exceptions true
-                                     :allow-circular-redirects true})))
-  (is (thrown-with-msg? Exception #"Maximum redirects \(50\) exceeded"
-                        (client/get (localhost "/redirect")
-                                    {:throw-exceptions true
-                                     :allow-circular-redirects true}))))
+  (with-open [s (run-server)]
+    (let [resp (client/get (localhost "/redirect")
+                           {:max-redirects 2 :throw-exceptions false
+                            :redirect-strategy :none
+                            :allow-circular-redirects true})]
+      (is (= 302 (:status resp)))
+      #_(is (= (apply vector (repeat 3 "http://localhost:18080/redirect"))
+               (:trace-redirects resp))))
+    (is (thrown-with-msg? Exception #"Maximum redirects \(2\) exceeded"
+                          (client/get (localhost "/redirect")
+                                      {:max-redirects 2
+                                       :throw-exceptions true
+                                       :allow-circular-redirects true})))
+    (is (thrown-with-msg? Exception #"Maximum redirects \(50\) exceeded"
+                          (client/get (localhost "/redirect")
+                                      {:throw-exceptions true
+                                       :allow-circular-redirects true})))))
 
 (deftest ^:integration get-with-body
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get-with-body"
-                       :body (.getBytes "foo bar")})]
-    (is (= 200 (:status resp)))
-    (is (= "foo bar" (String. (util/force-byte-array (:body resp)))))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :get :uri "/get-with-body"
+                         :body (.getBytes "foo bar")})]
+      (is (= 200 (:status resp)))
+      (is (= "foo bar" (String. (util/force-byte-array (:body resp))))))))
 
 (deftest ^:integration head-with-body
-  (run-server)
-  (let [resp (request {:request-method :head :uri "/head" :body "foo"})]
-    (is (= 200 (:status resp)))))
+  (with-open [s (run-server)]
+    (let [resp (request {:request-method :head :uri "/head" :body "foo"})]
+      (is (= 200 (:status resp))))))
 
 (deftest ^:integration t-clojure-output-coercion
-  (run-server)
-  (let [resp (client/get (localhost "/clojure") {:as :clojure})]
-    (is (= 200 (:status resp)))
-    (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}} (:body resp))))
-  (let [clj-resp (client/get (localhost "/clojure") {:as :auto})
-        edn-resp (client/get (localhost "/edn") {:as :auto})]
-    (is (= 200 (:status clj-resp) (:status edn-resp)))
-    (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}}
-           (:body clj-resp)
-           (:body edn-resp)))))
+  (with-open [s (run-server)]
+    (let [resp (client/get (localhost "/clojure") {:as :clojure})]
+      (is (= 200 (:status resp)))
+      (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}} (:body resp))))
+    (let [clj-resp (client/get (localhost "/clojure") {:as :auto})
+          edn-resp (client/get (localhost "/edn") {:as :auto})]
+      (is (= 200 (:status clj-resp) (:status edn-resp)))
+      (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}}
+             (:body clj-resp)
+             (:body edn-resp))))))
 
 (deftest ^:integration t-transit-output-coercion
-  (run-server)
-  (let [transit-json-resp (client/get (localhost "/transit-json") {:as :auto})
-        transit-msgpack-resp (client/get (localhost "/transit-msgpack")
-                                         {:as :auto})]
-    (is (= 200
-           (:status transit-json-resp)
-           (:status transit-msgpack-resp)))
-    (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}}
-           (:body transit-json-resp)
-           (:body transit-msgpack-resp)))))
+  (with-open [s (run-server)]
+    (let [transit-json-resp (client/get (localhost "/transit-json") {:as :auto})
+          transit-msgpack-resp (client/get (localhost "/transit-msgpack")
+                                           {:as :auto})]
+      (is (= 200
+             (:status transit-json-resp)
+             (:status transit-msgpack-resp)))
+      (is (= {:foo "bar" :baz 7M :eggplant {:quux #{1 2 3}}}
+             (:body transit-json-resp)
+             (:body transit-msgpack-resp))))))
 
 (deftest ^:integration t-json-output-coercion
-  (run-server)
-  (let [resp (client/get (localhost "/json") {:as :json})
-        resp-array (client/get (localhost "/json-array") {:as :json-strict})
-        resp-str (client/get (localhost "/json")
-                             {:as :json :coerce :exceptional})
-        resp-str-keys (client/get (localhost "/json") {:as :json-string-keys})
-        resp-strict-str-keys (client/get (localhost "/json")
-                                         {:as :json-strict-string-keys})
-        resp-auto (client/get (localhost "/json") {:as :auto})
-        bad-resp (client/get (localhost "/json-bad")
-                             {:throw-exceptions false :as :json})
-        bad-resp-json (client/get (localhost "/json-bad")
-                                  {:throw-exceptions false :as :json
-                                   :coerce :always})
-        bad-resp-json2 (client/get (localhost "/json-bad")
-                                   {:throw-exceptions false :as :json
-                                    :coerce :unexceptional})]
-    (is (= 200
-           (:status resp)
-           (:status resp-array)
-           (:status resp-str)
-           (:status resp-str-keys)
-           (:status resp-strict-str-keys)
-           (:status resp-auto)))
-    (is (= {:foo "bar"}
-           (:body resp)
-           (:body resp-auto)))
-    (is (= ["foo", "bar"]
-           (:body resp-array)))
-    (is (= {"foo" "bar"}
-           (:body resp-strict-str-keys)
-           (:body resp-str-keys)))
-    ;; '("foo" "bar") and ["foo" "bar"] compare as equal with =.
-    (is (vector? (:body resp-array)))
-    (is (= "{\"foo\":\"bar\"}" (:body resp-str)))
-    (is (= 400
-           (:status bad-resp)
-           (:status bad-resp-json)
-           (:status bad-resp-json2)))
-    (is (= "{\"foo\":\"bar\"}" (:body bad-resp))
-        "don't coerce on bad response status by default")
-    (is (= {:foo "bar"} (:body bad-resp-json)))
-    (is (= "{\"foo\":\"bar\"}" (:body bad-resp-json2)))))
+  (with-open [s (run-server)]
+    (let [resp (client/get (localhost "/json") {:as :json})
+          resp-array (client/get (localhost "/json-array") {:as :json-strict})
+          resp-str (client/get (localhost "/json")
+                               {:as :json :coerce :exceptional})
+          resp-str-keys (client/get (localhost "/json") {:as :json-string-keys})
+          resp-strict-str-keys (client/get (localhost "/json")
+                                           {:as :json-strict-string-keys})
+          resp-auto (client/get (localhost "/json") {:as :auto})
+          bad-resp (client/get (localhost "/json-bad")
+                               {:throw-exceptions false :as :json})
+          bad-resp-json (client/get (localhost "/json-bad")
+                                    {:throw-exceptions false :as :json
+                                     :coerce :always})
+          bad-resp-json2 (client/get (localhost "/json-bad")
+                                     {:throw-exceptions false :as :json
+                                      :coerce :unexceptional})]
+      (is (= 200
+             (:status resp)
+             (:status resp-array)
+             (:status resp-str)
+             (:status resp-str-keys)
+             (:status resp-strict-str-keys)
+             (:status resp-auto)))
+      (is (= {:foo "bar"}
+             (:body resp)
+             (:body resp-auto)))
+      (is (= ["foo", "bar"]
+             (:body resp-array)))
+      (is (= {"foo" "bar"}
+             (:body resp-strict-str-keys)
+             (:body resp-str-keys)))
+      ;; '("foo" "bar") and ["foo" "bar"] compare as equal with =.
+      (is (vector? (:body resp-array)))
+      (is (= "{\"foo\":\"bar\"}" (:body resp-str)))
+      (is (= 400
+             (:status bad-resp)
+             (:status bad-resp-json)
+             (:status bad-resp-json2)))
+      (is (= "{\"foo\":\"bar\"}" (:body bad-resp))
+          "don't coerce on bad response status by default")
+      (is (= {:foo "bar"} (:body bad-resp-json)))
+      (is (= "{\"foo\":\"bar\"}" (:body bad-resp-json2))))))
 
 (deftest ^:integration t-ipv6
-  (run-server)
-  (let [resp (client/get "http://[::1]:18080/get")]
-    (is (= 200 (:status resp)))
-    (is (= "get" (:body resp)))))
+  (with-open [s (run-server)]
+    (let [resp (client/get "http://[::1]:18080/get")]
+      (is (= 200 (:status resp)))
+      (is (= "get" (:body resp))))))
 
 (deftest t-custom-retry-handler
   (let [called? (atom false)]
@@ -405,71 +411,71 @@
 
 ;; super-basic test for methods that aren't used that often
 (deftest ^:integration t-copy-options-move
-  (run-server)
-  (let [resp1 (client/options (localhost "/options"))
-        resp2 (client/move (localhost "/move"))
-        resp3 (client/copy (localhost "/copy"))
-        resp4 (client/patch (localhost "/patch"))]
-    (is (= #{200} (set (map :status [resp1 resp2 resp3 resp4]))))
-    (is (= "options" (:body resp1)))
-    (is (= "move" (:body resp2)))
-    (is (= "copy" (:body resp3)))
-    (is (= "patch" (:body resp4)))))
+  (with-open [s (run-server)]
+    (let [resp1 (client/options (localhost "/options"))
+          resp2 (client/move (localhost "/move"))
+          resp3 (client/copy (localhost "/copy"))
+          resp4 (client/patch (localhost "/patch"))]
+      (is (= #{200} (set (map :status [resp1 resp2 resp3 resp4]))))
+      (is (= "options" (:body resp1)))
+      (is (= "move" (:body resp2)))
+      (is (= "copy" (:body resp3)))
+      (is (= "patch" (:body resp4))))))
 
 (deftest ^:integration t-json-encoded-form-params
-  (run-server)
-  (let [params {:param1 "value1" :param2 {:foo "bar"}}
-        resp (client/post (localhost "/post") {:content-type :json
-                                               :form-params params})]
-    (is (= 200 (:status resp)))
-    (is (= (json/encode params) (:body resp)))))
+  (with-open [s (run-server)]
+    (let [params {:param1 "value1" :param2 {:foo "bar"}}
+          resp (client/post (localhost "/post") {:content-type :json
+                                                 :form-params params})]
+      (is (= 200 (:status resp)))
+      (is (= (json/encode params) (:body resp))))))
 
 (deftest ^:integration t-request-interceptor
-  (run-server)
-  (let [req-ctx (atom [])
-        {:keys [status trace-redirects] :as resp}
-        (client/get
-         (localhost "/get")
-         {:request-interceptor
-          (fn [^HttpRequest req ^HttpContext ctx]
-            (reset! req-ctx {:method (.getMethod req) :uri (.getURI req)}))})]
-    (is (= 200 status))
-    (is (= "GET" (:method @req-ctx)))
-    (is (= "/get" (.getPath (:uri @req-ctx))))))
+  (with-open [s (run-server)]
+    (let [req-ctx (atom [])
+          {:keys [status trace-redirects] :as resp}
+          (client/get
+           (localhost "/get")
+           {:request-interceptor
+            (fn [^HttpRequest req ^HttpContext ctx]
+              (reset! req-ctx {:method (.getMethod req) :uri (.getURI req)}))})]
+      (is (= 200 status))
+      (is (= "GET" (:method @req-ctx)))
+      (is (= "/get" (.getPath (:uri @req-ctx)))))))
 
 (deftest ^:integration t-response-interceptor
-  (run-server)
-  (let [saved-ctx (atom [])
-        {:keys [status trace-redirects] :as resp}
-        (client/get
-         (localhost "/redirect-to-get")
-         {:response-interceptor
-          (fn [^HttpResponse resp ^HttpContext ctx]
-            (let [^HttpInetConnection conn
-                  (.getAttribute ctx ExecutionContext/HTTP_CONNECTION)]
-              (swap! saved-ctx conj {:remote-port (.getRemotePort conn)
-                                     :http-conn conn})))})]
-    (is (= 200 status))
-    (is (= 2 (count @saved-ctx)))
-    #_(is (= (count trace-redirects) (count @saved-ctx)))
-    (is (every? #(= 18080 (:remote-port %)) @saved-ctx))
-    (is (every? #(instance? HttpConnection (:http-conn %)) @saved-ctx))))
+  (with-open [s (run-server)]
+    (let [saved-ctx (atom [])
+          {:keys [status trace-redirects] :as resp}
+          (client/get
+           (localhost "/redirect-to-get")
+           {:response-interceptor
+            (fn [^HttpResponse resp ^HttpContext ctx]
+              (let [^HttpInetConnection conn
+                    (.getAttribute ctx ExecutionContext/HTTP_CONNECTION)]
+                (swap! saved-ctx conj {:remote-port (.getRemotePort conn)
+                                       :http-conn conn})))})]
+      (is (= 200 status))
+      (is (= 2 (count @saved-ctx)))
+      #_(is (= (count trace-redirects) (count @saved-ctx)))
+      (is (every? #(= 18080 (:remote-port %)) @saved-ctx))
+      (is (every? #(instance? HttpConnection (:http-conn %)) @saved-ctx)))))
 
 (deftest ^:integration t-send-input-stream-body
-  (run-server)
-  (let [b1 (:body (client/post "http://localhost:18080/post"
-                               {:body (ByteArrayInputStream. (.getBytes "foo"))
-                                :length 3}))
-        b2 (:body (client/post "http://localhost:18080/post"
-                               {:body (ByteArrayInputStream.
-                                       (.getBytes "foo"))}))
-        b3 (:body (client/post "http://localhost:18080/post"
-                               {:body (ByteArrayInputStream.
-                                       (.getBytes "apple"))
-                                :length 2}))]
-    (is (= b1 "foo"))
-    (is (= b2 "foo"))
-    (is (= b3 "ap"))))
+  (with-open [s (run-server)]
+    (let [b1 (:body (client/post "http://localhost:18080/post"
+                                 {:body (ByteArrayInputStream. (.getBytes "foo"))
+                                  :length 3}))
+          b2 (:body (client/post "http://localhost:18080/post"
+                                 {:body (ByteArrayInputStream.
+                                         (.getBytes "foo"))}))
+          b3 (:body (client/post "http://localhost:18080/post"
+                                 {:body (ByteArrayInputStream.
+                                         (.getBytes "apple"))
+                                  :length 2}))]
+      (is (= b1 "foo"))
+      (is (= b2 "foo"))
+      (is (= b3 "ap")))))
 
 ;; (deftest t-add-client-params
 ;;   (testing "Using add-client-params!"
@@ -520,55 +526,55 @@
 ;; This relies on connections to writequit.org being slower than 10ms, if this
 ;; fails, you must have very nice internet.
 (deftest ^:integration sets-conn-timeout
-  (run-server)
-  (try
-    (is (thrown? SocketTimeoutException
-                 (client/request {:scheme :http
-                                  :server-name "www.writequit.org"
-                                  :server-port 80
-                                  :request-method :get :uri "/"
-                                  :conn-timeout 10})))))
+  (with-open [s (run-server)]
+    (try
+      (is (thrown? SocketTimeoutException
+                   (client/request {:scheme :http
+                                    :server-name "www.writequit.org"
+                                    :server-port 80
+                                    :request-method :get :uri "/"
+                                    :conn-timeout 10}))))))
 
 (deftest ^:integration connection-pool-timeout
-  (run-server)
-  (client/with-connection-pool {:threads 1 :default-per-route 1}
-    (let [async-request #(future (client/request {:scheme :http
-                                                  :server-name "localhost"
-                                                  :server-port 18080
-                                                  :request-method :get
-                                                  :conn-timeout 1
-                                                  :conn-request-timeout 1
-                                                  :uri "/timeout"}))
-          is-pool-timeout-error?
-          (fn [req-fut]
-            (instance? org.apache.http.conn.ConnectionPoolTimeoutException
-                       (try @req-fut (catch Exception e (.getCause e)))))
-          req1 (async-request)
-          req2 (async-request)
-          timeout-error1 (is-pool-timeout-error? req1)
-          timeout-error2 (is-pool-timeout-error? req2)]
-      (is (or timeout-error1 timeout-error2)))))
+  (with-open [s (run-server)]
+    (client/with-connection-pool {:threads 1 :default-per-route 1}
+      (let [async-request #(future (client/request {:scheme :http
+                                                    :server-name "localhost"
+                                                    :server-port 18080
+                                                    :request-method :get
+                                                    :conn-timeout 1
+                                                    :conn-request-timeout 1
+                                                    :uri "/timeout"}))
+            is-pool-timeout-error?
+            (fn [req-fut]
+              (instance? org.apache.http.conn.ConnectionPoolTimeoutException
+                         (try @req-fut (catch Exception e (.getCause e)))))
+            req1 (async-request)
+            req2 (async-request)
+            timeout-error1 (is-pool-timeout-error? req1)
+            timeout-error2 (is-pool-timeout-error? req2)]
+        (is (or timeout-error1 timeout-error2))))))
 
 (deftest ^:integration t-header-collections
-  (run-server)
-  (let [headers (-> (client/get "http://localhost:18080/headers"
-                                {:headers {"foo" ["bar" "baz"]
-                                           "eggplant" "quux"}})
-                    :body
-                    json/decode)]
-    (is (= {"eggplant" "quux" "foo" "bar,baz"}
-           (select-keys headers ["foo" "eggplant"])))))
+  (with-open [s (run-server)]
+    (let [headers (-> (client/get "http://localhost:18080/headers"
+                                  {:headers {"foo" ["bar" "baz"]
+                                             "eggplant" "quux"}})
+                      :body
+                      json/decode)]
+      (is (= {"eggplant" "quux" "foo" "bar,baz"}
+             (select-keys headers ["foo" "eggplant"]))))))
 
 (deftest ^:integration t-clojure-no-read-eval
-  (run-server)
-  (is (thrown? Exception (client/get (localhost "/clojure-bad") {:as :clojure}))
-      "Should throw an exception when reading clojure eval components"))
+  (with-open [s (run-server)]
+    (is (thrown? Exception (client/get (localhost "/clojure-bad") {:as :clojure}))
+        "Should throw an exception when reading clojure eval components")))
 
 (deftest ^:integration t-numeric-headers
-  (run-server)
-  (client/request {:method :get :url (localhost "/get") :headers {"foo" 2}}))
+  (with-open [s (run-server)]
+    (client/request {:method :get :url (localhost "/get") :headers {"foo" 2}})))
 
 (deftest ^:integration t-empty-response-coercion
-   (run-server)
-   (let [resp (client/get (localhost "/empty") {:as :clojure})]
-     (is (= (:body resp) nil))))
+  (with-open [s (run-server)]
+    (let [resp (client/get (localhost "/empty") {:as :clojure})]
+      (is (= (:body resp) nil)))))


### PR DESCRIPTION
- add protocol Closable
- extend Closable to Jetty
- use `with-open` when running jetty to make sure it's closed for each test
- reindent code (unfortunately)

this allows `lein test :all` to run without errors