### PR TITLE
Example should use (into) instead of (concat)

### DIFF
--- a/examples/progress_download.clj
+++ b/examples/progress_download.clj
@@ -27,7 +27,7 @@
   "Addes value into a vector at an specific index."
   (-> (subvec v 0 idx)
       (conj val)
-      (concat (subvec v idx))))
+      (into (subvec v idx))))
 
 (defn insert-after [v needle val]
   "Finds an item into a vector and adds val just after it.


### PR DESCRIPTION
Was testing this out and trying to add another middleware using `(insert-after)` and it blew up. `(concat)` returns a lazy sequence, and the next time calling `(subvec)` it blows up... Switching to `(into)` solved it since it preserves the vector type.