### PR TITLE
fix NPE in  Populate the :trace-redirects response field #327 PR

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -326,7 +326,7 @@
       :else
       (respond* resp-r req))))
 
-(defn wrap-redirects
+(defn ^:deprecated wrap-redirects
   "Middleware that follows redirects in the response. A slingshot exception is
   thrown if too many redirects occur. Options
 
@@ -1072,7 +1072,6 @@
    wrap-oauth
    wrap-user-info
    wrap-url
-   wrap-redirects
    wrap-decompression
    wrap-input-coercion
    ;; put this before output-coercion, so additional charset

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -309,7 +309,7 @@
                          :major (.getMajor protocol-version)
                          :minor (.getMinor protocol-version)}
      :reason-phrase (.getReasonPhrase status)
-     :trace-redirects (mapv #(.toString %)
+     :trace-redirects (mapv str
                             (into [] (.getRedirectLocations context)))}))
 
 (defn- get-conn-mgr

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -292,7 +292,7 @@
   (clojure.pprint/pprint (bean http-req)))
 
 (defn- build-response-map
-  [^HttpResponse response req conn-mgr]
+  [^HttpResponse response req conn-mgr context]
   (let [^HttpEntity entity (.getEntity response)
         status (.getStatusLine response)
         protocol-version (.getProtocolVersion status)]
@@ -308,7 +308,9 @@
      :protocol-version  {:name (.getProtocol protocol-version)
                          :major (.getMajor protocol-version)
                          :minor (.getMinor protocol-version)}
-     :reason-phrase (.getReasonPhrase status)}))
+     :reason-phrase (.getReasonPhrase status)
+     :trace-redirects (mapv #(.toString %)
+                            (into [] (.getRedirectLocations context)))}))
 
 (defn- get-conn-mgr
   [async? req]
@@ -384,7 +386,7 @@
        (let [^CloseableHttpClient client (http-client req conn-mgr http-url
                                                       proxy-ignore-hosts)]
          (try
-           (build-response-map (.execute client http-req context) req conn-mgr)
+           (build-response-map (.execute client http-req context) req conn-mgr context)
            (catch Throwable t
              (when-not (conn/reusable? conn-mgr)
                (.shutdown conn-mgr))
@@ -402,7 +404,7 @@
                          (raise ex)))
                      (completed [this resp]
                        (try
-                         (respond (build-response-map resp req conn-mgr))
+                         (respond (build-response-map resp req conn-mgr context))
                          (catch Throwable t
                            (when-not (conn/reusable? conn-mgr)
                              (.shutdown conn-mgr))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1338,11 +1338,11 @@
       (binding [client/*pooling-info*
                 (assoc client/*pooling-info* :release (count-release count))]
         (request {:async? true :uri "/redirect-to-get"
-                  :method :get :redirect-strategy :none} resp exce)
+                  :method :get :redirect-strategy :default} resp exce)
         (is (= 200 (:status @resp)))
         (is (:pooling-info @resp))
         (is (not (realized? exce)))
-        (is (= 0 @count))))))
+        (is (= 1 @count))))))
 
 (deftest ^:integration t-async-pool-max-redirect
   (run-server)
@@ -1351,11 +1351,11 @@
       (binding [client/*pooling-info*
                 (assoc client/*pooling-info* :release (count-release count))]
         (request {:async? true :uri "/redirect" :method :get
-                  :redirect-strategy :none
+                  :redirect-strategy :default
                   :throw-exceptions true} resp exce)
         (is @exce)
         (is (not (realized? resp)))
-        (is (= 0 @count))))))
+        (is (= 20 @count))))))
 
 (deftest test-url-encode-path
   (is (= (client/url-encode-illegal-characters "?foo bar+baz[]75")

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -572,3 +572,8 @@
    (run-server)
    (let [resp (client/get (localhost "/empty") {:as :clojure})]
      (is (= (:body resp) nil))))
+
+(deftest ^:integration t-once-trace-redirects
+  (run-server)
+  (let [resp (client/request {:method :get :url (localhost "/redirect-to-get")})]
+    (is (= (:trace-redirects resp) ["http://localhost:18080/get"]))))

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -573,7 +573,12 @@
    (let [resp (client/get (localhost "/empty") {:as :clojure})]
      (is (= (:body resp) nil))))
 
-(deftest ^:integration t-once-trace-redirects
+(deftest ^:integration t-trace-redirects
   (run-server)
-  (let [resp (client/request {:method :get :url (localhost "/redirect-to-get")})]
-    (is (= (:trace-redirects resp) ["http://localhost:18080/get"]))))
+  (let [resp-with-redirects (client/request {:method :get
+                                             :url (localhost "/redirect-to-get")})
+        resp-without-redirects (client/request {:method :get
+                                                :url (localhost "/redirect-to-get")
+                                                :follow-redirects false})]
+    (is (= (:trace-redirects resp-with-redirects) ["http://localhost:18080/get"]))
+    (is (= (:trace-redirects resp-without-redirects) []))))


### PR DESCRIPTION
In order to fix NPE in #327 , I have to update two tests dealing with redirect , since I have removed `wrap-redirects` middleware, so it is impossible for clj-http to control redirect behavior