### PR TITLE
Point out optional dependency for output coercion

### DIFF
--- a/README.org
+++ b/README.org
@@ -449,6 +449,8 @@ All exceptions thrown during the request will be passed to the raise callback.
 ;; stream has been read
 #+END_SRC
 
+Output coercion with =:as :json=, =:as :json-strict=, =:as :json-strict-string-keys=, =:as :json-string-keys= or =:as :x-www-form-urlencoded= will only work with an optional dependency, see [[#optional-dependencies][Optional Dependencies]].
+
 JSON coercion defaults to only an "unexceptional" statuses, meaning status codes
 in the #{200 201 202 203 204 205 206 207 300 301 302 303 307} range. If you
 would like to change this, you can send the =:coerce= option, which can be set


### PR DESCRIPTION
Using (client/get ... {:as :json}) without the [chesire] dependency, will keep the :body as a String rather than parse the body as json. Much later in the README there is a section on Option Dependencies that refers to this. This note is to save other readers some time.