### PR TITLE
:type selector added

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -218,9 +218,10 @@
     resp
     (if (false? (opt req :throw-exceptions))
       resp
-      (if (opt req :throw-entire-message)
-        (throw+ resp "clj-http: status %d %s" (:status %) resp)
-        (throw+ resp "clj-http: status %s" (:status %))))))
+      (let [data (assoc resp :type ::unexceptional-status)]
+        (if (opt req :throw-entire-message)
+          (throw+ data "clj-http: status %d %s" (:status %) resp)
+          (throw+ data "clj-http: status %s" (:status %)))))))
 
 (defn wrap-exceptions
   "Middleware that throws a slingshot exception if the response is not a


### PR DESCRIPTION
Some Clojure frameworks allow to catch slingshot exceptions by a `:type` field, e.g. [Compojure API](https://github.com/metosin/compojure-api/) (see [the wiki docs](https://github.com/metosin/compojure-api/wiki/Exception-handling)). It would be great I think to catch any HTTP exception with just a `:type` selector no matter what the status code was:

```
(catch [:type :clj-http.client/unexceptional-status] {:keys [status]}
   ... (log-status-code status)
```
