### PR TITLE
Append (not replace) default encodings to custom encodings

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -335,7 +335,8 @@
   (fn [req]
     (if (false? (opt req :decompress-body))
       (client req)
-      (let [req-c (update req :headers assoc "accept-encoding" "gzip, deflate")
+      (let [merge-encodings (fn [e] (str/join ", " (remove nil? [e "gzip, deflate"])))
+            req-c (update-in req [:headers "accept-encoding"] merge-encodings)
             resp-c (client req-c)]
         (decompress-body resp-c)))))
 

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -324,6 +324,26 @@
               {:accept-encoding [:identity :gzip]}
               {:headers {"accept-encoding" "identity, gzip"}}))
 
+(deftest apply-custom-accept-encoding
+  (testing "no custom encodings to accept"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {}
+                {:headers {"accept-encoding" "gzip, deflate"}
+                 :orig-content-encoding nil}))
+  (testing "accept some custom encodings, but still include gzip and deflate"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {:accept-encoding [:foo :bar]}
+                {:headers {"accept-encoding" "foo, bar, gzip, deflate"}
+                 :orig-content-encoding nil}))
+  (testing "accept some custom encodings, but exclude gzip and deflate"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {:accept-encoding [:foo :bar] :decompress-body false}
+                {:headers {"accept-encoding" "foo, bar"}
+                 :decompress-body false})))
+
 (deftest pass-on-no-accept-encoding
   (is-passed client/wrap-accept-encoding
              {:uri "/foo"}))


### PR DESCRIPTION
Before, any custom "accept-encoding" header via the `wrap-accept-encoding` middleware would be replaced by the `wrap-decompression` middleware. The new `wrap-decompression` middleware tries to merge any existing values in the "accept-encoding" header.