### PR TITLE
Append (not replace) default encodings to custom encodings

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -380,7 +380,8 @@
   [req]
   (if (false? (opt req :decompress-body))
     req
-    (update req :headers assoc "accept-encoding" "gzip, deflate")))
+    (update-in req [:headers "accept-encoding"]
+               #(str/join ", " (remove nil? [% "gzip, deflate"])))))
 
 (defn- decompression-response
   [req resp]

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -681,6 +681,26 @@
               {:accept-encoding [:identity :gzip]}
               {:headers {"accept-encoding" "identity, gzip"}}))
 
+(deftest apply-custom-accept-encoding
+  (testing "no custom encodings to accept"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {}
+                {:headers {"accept-encoding" "gzip, deflate"}
+                 :orig-content-encoding nil}))
+  (testing "accept some custom encodings, but still include gzip and deflate"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {:accept-encoding [:foo :bar]}
+                {:headers {"accept-encoding" "foo, bar, gzip, deflate"}
+                 :orig-content-encoding nil}))
+  (testing "accept some custom encodings, but exclude gzip and deflate"
+    (is-applied (comp client/wrap-accept-encoding
+                      client/wrap-decompression)
+                {:accept-encoding [:foo :bar] :decompress-body false}
+                {:headers {"accept-encoding" "foo, bar"}
+                 :decompress-body false})))
+
 (deftest pass-on-no-accept-encoding
   (is-passed client/wrap-accept-encoding
              {:uri "/foo"}))


### PR DESCRIPTION
Same as #351 but for the latest and greatest.

From #351:
Before, any custom "accept-encoding" header via the wrap-accept-encoding middleware would be replaced by the wrap-decompression middleware. The new wrap-decompression middleware tries to merge any existing values in the "accept-encoding" header.