### PR TITLE
Configure 1ms grace for regular async conn manager

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -179,7 +179,11 @@
 
                              :else regular-strategy-registry)]
     (doto
-        (PoolingNHttpClientConnectionManager. (default-ioreactor) registry)
+        (PoolingNHttpClientConnectionManager. (-> (IOReactorConfig/custom)
+                                                  (.setShutdownGracePeriod 1)
+                                                  .build
+                                                  DefaultConnectingIOReactor.)
+                                              registry)
       (.setMaxTotal 1))))
 
 (definterface ReuseableAsyncConnectionManager)


### PR DESCRIPTION
Hi,

Currently, when we shut down the regular async connection manager from the callback (in the input stream proxy), we incur a one second delay (in fact two 500 ms delays):

```
clj-http.client> (time (let [res (promise)] (request {:method :get :url "http://ipinfo.io//json" :async? true} #(deliver res %) println) @res nil))
"Elapsed time: 1026.317641 msecs"
nil
```

This pull request configures the minimal shutdown grace period for the IO reactor to reduce this delay to 2 ms:

```
clj-http.client> (time (let [res (promise)] (request {:method :get :url "http://ipinfo.io//json" :async? true} #(deliver res %) println) @res nil))
"Elapsed time: 33.162948 msecs"
nil
```
