### PR TITLE
Fix for issue 357

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -119,7 +119,7 @@
     (apply get-keystore* keystore args)))
 
 (defn get-keystore-context-verifier
-  [{:keys [keystore keystore-type keystore-pass keystore-instance
+  [{:keys [keystore keystore-type ^String keystore-pass keystore-instance   ; Note: JVM strings aren't ideal for passwords - see http://stackoverflow.com/questions/8881291/why-is-char-preferred-over-string-for-passwords
            trust-store trust-store-type trust-store-pass]
     :as req}]
   (let [ks (get-keystore keystore keystore-type keystore-pass)
@@ -274,7 +274,7 @@
 
 (defn shutdown-manager
   "Shut down the given connection manager, if it is not nil"
-  [manager]
+  [^org.apache.http.conn.HttpClientConnectionManager manager]
   (and manager (.shutdown manager)))
 
 (def ^:dynamic *connection-manager*

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -16,6 +16,7 @@
                                       PoolingHttpClientConnectionManager)
            (org.apache.http.impl.nio.conn PoolingNHttpClientConnectionManager)
            (javax.net.ssl SSLContext HostnameVerifier)
+           (org.apache.http.nio.conn NHttpClientConnectionManager)
            (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
            (org.apache.http.impl.nio.reactor
             IOReactorConfig
@@ -272,10 +273,12 @@
       (.setDefaultMaxPerRoute conn-man default-per-route))
     conn-man))
 
-(defn shutdown-manager
+(defmulti shutdown-manager
   "Shut down the given connection manager, if it is not nil"
-  [^org.apache.http.conn.HttpClientConnectionManager manager]
-  (and manager (.shutdown manager)))
+  class)
+(defmethod shutdown-manager nil                                                   [conn-mgr] nil)
+(defmethod shutdown-manager org.apache.http.conn.HttpClientConnectionManager      [^HttpClientConnectionManager  conn-mgr] (.shutdown conn-mgr))
+(defmethod shutdown-manager org.apache.http.nio.conn.NHttpClientConnectionManager [^NHttpClientConnectionManager conn-mgr] (.shutdown conn-mgr))
 
 (def ^:dynamic *connection-manager*
   "connection manager to be rebound during request execution"

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -320,7 +320,7 @@
     (or conn/*connection-manager*
         (conn/make-regular-conn-manager req))))
 
-(defmulti ^:private  shutdown class)
+(defmulti ^:private shutdown class)
 (defmethod shutdown org.apache.http.conn.HttpClientConnectionManager      [^HttpClientConnectionManager  conn-mgr] (.shutdown conn-mgr))
 (defmethod shutdown org.apache.http.nio.conn.NHttpClientConnectionManager [^NHttpClientConnectionManager conn-mgr] (.shutdown conn-mgr))
 

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -96,17 +96,22 @@
     (throw (Exception. (str "Multipart byte array body must contain "
                             "at least :content and :name")))))
 
+(defmulti  ^java.nio.charset.Charset encoding-to-charset class)
+(defmethod encoding-to-charset nil                      [encoding] nil)
+(defmethod encoding-to-charset java.nio.charset.Charset [encoding] encoding)
+(defmethod encoding-to-charset java.lang.String         [encoding] (java.nio.charset.Charset/forName encoding))
+
 (defmethod make-multipart-body String
   ;; Create a StringBody object from the given map, requiring at least :content.
   ;; If :encoding is specified, it will be created using the Charset for that
   ;; encoding.
-  [{:keys [mime-type ^String content encoding]}]
+  [{:keys [^String mime-type ^String content encoding]}]
   (cond
     (and content mime-type encoding)
-    (StringBody. content (ContentType/create mime-type encoding))
+    (StringBody. content (ContentType/create mime-type (encoding-to-charset encoding)))
 
     (and content encoding)
-    (StringBody. content (ContentType/create "text/plain" encoding))
+    (StringBody. content (ContentType/create "text/plain" (encoding-to-charset encoding)))
 
     content
     (StringBody. content (ContentType/create "text/plain" Consts/ASCII))))


### PR DESCRIPTION
This PR fixes issue #357 - removing all reflection warnings reported by `lein check`, and is an updated / corrected version of PR #358.

All unit tests continue to pass (output below), though I haven't done any integration testing.  Given how widely used this library is, and my relatively light Clojure experience, I would encourage careful review and as much testing as possible before merging.

**Important design note for PR reviewers:** I chose to use multimethods where type-specific code was needed, even though protocols would also have worked.  There is no strong reason for this (beyond personal preference), so feel free to change it if you feel that's appropriate.

Output from `lein do check, test`:
```
$ lein do check, test
Compiling namespace clj-http.client
Compiling namespace clj-http.conn-mgr
Compiling namespace clj-http.cookies
Compiling namespace clj-http.core
Compiling namespace clj-http.core-old
Compiling namespace clj-http.headers
Compiling namespace clj-http.links
Compiling namespace clj-http.multipart
Compiling namespace clj-http.util
2017-03-19 16:35:04.588:INFO::main: Logging initialized @2970ms

lein test clj-http.test.client-test
Deprecated use of :transit-opts found.
Deprecated use of :transit-opts found.

lein test clj-http.test.conn-mgr-test

lein test clj-http.test.cookies-test

lein test clj-http.test.core-test

lein test clj-http.test.headers-test

lein test clj-http.test.links-test

lein test clj-http.test.multipart-test

lein test clj-http.test.util-test

Ran 116 tests containing 2361 assertions.
0 failures, 0 errors.
$
```