### PR TITLE
Add Graceful Redirects

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -84,7 +84,9 @@
     :default (DefaultRedirectStrategy/INSTANCE)
     :lax (LaxRedirectStrategy.)
     nil (DefaultRedirectStrategy/INSTANCE)
-    (DefaultRedirectStrategy/INSTANCE)))
+
+    ;; use directly as reifed RedirectStrategy
+    redirect-strategy))
 
 (defn ^HttpClientBuilder add-retry-handler [^HttpClientBuilder builder handler]
   (when handler

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -109,7 +109,6 @@
 (defn request-config [{:keys [conn-timeout
                               socket-timeout
                               conn-request-timeout
-                              follow-redirects
                               max-redirects
                               allow-circular-redirects
                               allow-relative-redirects
@@ -119,8 +118,7 @@
                    (.setSocketTimeout (or socket-timeout -1))
                    (.setConnectionRequestTimeout
                     (or conn-request-timeout -1))
-                   (.setRedirectsEnabled ((complement false?)
-                                          follow-redirects))
+                   (.setRedirectsEnabled true)
                    (.setCircularRedirectsAllowed
                     (boolean allow-circular-redirects))
                    (.setRelativeRedirectsAllowed
@@ -349,7 +347,7 @@
   ([req] (request req nil nil))
   ([{:keys [body conn-timeout conn-request-timeout connection-manager
             cookie-store cookie-policy headers multipart query-string
-            redirect-strategy follow-redirects max-redirects retry-handler
+            redirect-strategy max-redirects retry-handler
             request-method scheme server-name server-port socket-timeout
             uri response-interceptor proxy-host proxy-port async?
             proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth]

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -289,9 +289,17 @@
                          {:max-redirects 2 :throw-exceptions false
                           :redirect-strategy :none
                           :allow-circular-redirects true})]
+    (is (= 302 (:status resp))))
+
+  (let [resp (client/get (localhost "/redirect")
+                         {:max-redirects 3
+                          :redirect-strategy :graceful
+                          :allow-circular-redirects true})]
     (is (= 302 (:status resp)))
-    #_(is (= (apply vector (repeat 3 "http://localhost:18080/redirect"))
-             (:trace-redirects resp))))
+    (is (= 3 (count (:trace-redirects resp))))
+    (is (=  ["http://localhost:18080/redirect" "http://localhost:18080/redirect" "http://localhost:18080/redirect"]
+            (:trace-redirects resp))))
+
   (is (thrown-with-msg? Exception #"Maximum redirects \(2\) exceeded"
                         (client/get (localhost "/redirect")
                                     {:max-redirects 2

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -586,10 +586,21 @@
   (let [resp-with-redirects
         (client/request {:method :get
                          :url (localhost "/redirect-to-get")})
+
+        resp-with-graceful-redirects
+        (client/request {:method :get
+                         :url (localhost "/redirect-to-get")
+                         :redirect-strategy :graceful})
+
         resp-without-redirects
         (client/request {:method :get
                          :url (localhost "/redirect-to-get")
-                         :follow-redirects false})]
+                         :redirect-strategy :none})]
+
     (is (= (:trace-redirects resp-with-redirects)
            ["http://localhost:18080/get"]))
+
+    (is (= (:trace-redirects resp-with-graceful-redirects)
+           ["http://localhost:18080/get"]))
+
     (is (= (:trace-redirects resp-without-redirects) []))))


### PR DESCRIPTION
Adds a new `:graceful` option to `get-redirect-strategy` which behaves like `:throw-exceptions false` when the max number of redirects is encountered.

Also relaxes `get-redirect-strategy` to allow library users to pass in their own reified RedirectStrategy.

Solves #361 