### PR TITLE
Add unparse function

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -183,6 +183,19 @@
                   (util/url-decode user-info))
      :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
 
+(defn unparse-url
+  "Takes a map of url-parts and generates a string representation"
+  [{:keys [scheme server-name server-port uri user-info query-string]}]
+  (str (name scheme) "://"
+       (if (seq user-info)
+         (str user-info "@" server-name)
+         server-name)
+       (when server-port
+         (str ":" server-port))
+       uri
+       (when (seq query-string)
+         (str "?" query-string))))
+
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?
   #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -949,6 +949,17 @@
              client/parse-url
              :user-info))))
 
+(deftest unparse-url
+  (is (= "http://fred's diner:fred's password@example.com/foo"
+         (-> "http://fred%27s%20diner:fred%27s%20password@example.com/foo"
+             client/parse-url client/unparse-url)))
+  (is (= "https://foo:bar@vg.no:8080"
+         (-> "https://foo:bar@vg.no:8080"
+             client/parse-url client/unparse-url)))
+  (is (= "ftp://lol.com?foo"
+         (-> "ftp://lol.com?foo"
+             client/parse-url client/unparse-url))))
+
 (defrecord Point [x y])
 
 (def write-point


### PR DESCRIPTION
- add a simple function which returns a string representing an URL
- expects to be handed a map produced by `parse-url`
- no encoding is done

fixes #344