### PR TITLE
Allow RequestConfig and HttpClientContext to be injected

### DIFF
--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -11,6 +11,8 @@
            (org.apache.http.params CoreConnectionPNames CoreProtocolPNames)
            (org.apache.http.message BasicHeader BasicHeaderIterator)
            (org.apache.http.client.methods HttpPost)
+           (org.apache.http.client.protocol HttpClientContext)
+           (org.apache.http.client.config RequestConfig)
            (org.apache.http.client.params CookiePolicy ClientPNames)
            (org.apache.http HttpRequest HttpResponse HttpConnection
                             HttpInetConnection HttpVersion)
@@ -604,3 +606,23 @@
            ["http://localhost:18080/get"]))
 
     (is (= (:trace-redirects resp-without-redirects) []))))
+
+(deftest ^:integration t-override-request-config
+  (run-server)
+  (let [called-args (atom [])
+        real-http-client core/http-client
+        http-context (HttpClientContext/create)
+        request-config (.build (RequestConfig/custom))]
+    (with-redefs [core/http-client (fn [& args]
+                                     (proxy [org.apache.http.impl.client.CloseableHttpClient] []
+                                       (execute [http-req context]
+                                         (swap! called-args conj [http-req context])
+                                         (.execute (apply real-http-client args) http-req context))))]
+      (client/request {:method :get
+                       :url "http://localhost:18080/get"
+                       :http-client-context http-context
+                       :http-request-config request-config})
+
+      (let [context-for-request (last (last @called-args))]
+      (is (= http-context context-for-request))
+      (is (= request-config (.getRequestConfig context-for-request)))))))


### PR DESCRIPTION
This allows the `RequestConfig` and `HttpClientContext` instances to be overridden.

It is done like so:

```clojure
(client/request {:method :get
                 :url "http://localhost:18080/get"
                 :http-client-context my-http-client-context
                 :http-request-config my-request-config})
```

We thinks this allows for more flexibility. In our case, it helps us do some fancier things with proxies. We want to set an `AuthCache` on our `HttpClientContext` instance, which looks something like this:

```clojure
;; Our code looks like this...
(defn additional-cljhttp-options [proxy-host proxy-port proxy-user proxy-pass]
  (let [host (HttpHost. proxy-host proxy-port "http")
        creds (doto (BasicCredentialsProvider.)
                (.setCredentials AuthScope/ANY (UsernamePasswordCredentials. proxy-user proxy-pass)))
        basic-scheme (doto (BasicScheme.)
                       (.processChallenge (BasicHeader. HttpHeaders/PROXY_AUTHENTICATE "Basic")))
        auth-cache (doto (BasicAuthCache.)
                     (.put host basic-scheme))
        context (doto (HttpClientContext/create)
                  (.setCredentialsProvider creds)
                  (.setAuthCache auth-cache))
        request-config (-> (RequestConfig/custom) (.setProxy host) (.build))]
    {:http-client-context context :http-request-config request-config}))
```

This seems like it would also help solve #307 and allow SOCKS authentication to be provided, and perhaps help with #225.

Feedback is welcome, especially on some of the naming and spying done in the new test.