### PR TITLE
Library now has over two million downloads

### DIFF
--- a/README.org
+++ b/README.org
@@ -1121,7 +1121,7 @@ $ lein all test :all
 :CUSTOM_ID: h:3044d1f7-6772-43c2-9ded-8c71c7f9ada2
 :END:
 
-With close to a [[https://clojars.org/clj-http][million]] downloads, clj-http is a
+With over [[https://clojars.org/clj-http][two million]] downloads, clj-http is a
 widely used, battle-tested clojure library. It is also included in other
 libraries (like database clients) as a low-level http wrapper.
 


### PR DESCRIPTION
As of this writing, clj-http has 2,257,115 downloads on Clojars. This should be noted in the readme.