### PR TITLE
Add http scheme/session on custom keystore connections

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -145,6 +145,7 @@
         factory (SSLConnectionSocketFactory. ^SSLContext context
                                              ^HostnameVerifier verifier)]
     (-> (RegistryBuilder/create)
+        (.register "http" (PlainConnectionSocketFactory/getSocketFactory))
         (.register "https" factory)
         (.build))))
 

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -155,6 +155,7 @@
         strategy (SSLIOSessionStrategy. ^SSLContext context
                                         ^HostnameVerifier verifier)]
     (-> (RegistryBuilder/create)
+        (.register "http" NoopIOSessionStrategy/INSTANCE)
         (.register "https" strategy)
         (.build))))
 

--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -10,7 +10,10 @@
                                      DefaultHostnameVerifier
                                      NoopHostnameVerifier
                                      TrustStrategy)
-           (org.apache.http.conn.socket PlainConnectionSocketFactory)))
+           (org.apache.http.conn.socket PlainConnectionSocketFactory)
+           (org.apache.http.nio.conn NoopIOSessionStrategy)
+           (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
+           ))
 
 (def client-ks "test-resources/client-keystore")
 (def client-ks-pass "keykey")
@@ -48,6 +51,16 @@
         ssl-socket-factory (.lookup sr "https")]
     (is (instance? PlainConnectionSocketFactory plain-socket-factory))
     (is (instance? SSLConnectionSocketFactory ssl-socket-factory))
+    ))
+
+(deftest keystore-session-strategy
+  (let [strategy-registry (conn-mgr/get-keystore-strategy-registry
+                            {:keystore client-ks :keystore-pass client-ks-pass
+                             :trust-store client-ks :trust-store-pass client-ks-pass})
+        noop-session-strategy (.lookup strategy-registry "http")
+        ssl-session-strategy (.lookup strategy-registry "https")]
+    (is (instance? NoopIOSessionStrategy noop-session-strategy))
+    (is (instance? SSLIOSessionStrategy ssl-session-strategy))
     ))
 
 (deftest ^:integration ssl-client-cert-get

--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -9,7 +9,8 @@
            (org.apache.http.conn.ssl SSLConnectionSocketFactory
                                      DefaultHostnameVerifier
                                      NoopHostnameVerifier
-                                     TrustStrategy)))
+                                     TrustStrategy)
+           (org.apache.http.conn.socket PlainConnectionSocketFactory)))
 
 (def client-ks "test-resources/client-keystore")
 (def client-ks-pass "keykey")
@@ -43,8 +44,11 @@
   (let [sr (conn-mgr/get-keystore-scheme-registry
             {:keystore client-ks :keystore-pass client-ks-pass
              :trust-store client-ks :trust-store-pass client-ks-pass})
-        socket-factory (.lookup sr "https")]
-    (is (instance? SSLConnectionSocketFactory socket-factory))))
+        plain-socket-factory (.lookup sr "http")
+        ssl-socket-factory (.lookup sr "https")]
+    (is (instance? PlainConnectionSocketFactory plain-socket-factory))
+    (is (instance? SSLConnectionSocketFactory ssl-socket-factory))
+    ))
 
 (deftest ^:integration ssl-client-cert-get
   (let [server (ring/run-jetty secure-handler


### PR DESCRIPTION
This adds support for a http scheme/session for custom keystore connection managers. It is required for connections via proxy.

Solves Issue #380