### PR TITLE
Don't hang when async test is failing

### DIFF
--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -96,11 +96,11 @@
                                 :server-port 18084 :scheme :https
                                 :insecure? true :server-name "localhost"
                                 :async? true} resp exception)]
-        (is (= 403 (:status @resp))))
+        (is (= 403 (:status (deref resp 1000 {:status :timeout})))))
       (let [resp (promise)
             exception (promise)
             _ (core/request (assoc secure-request :async? true) resp exception)]
-        (is (= 200 (:status @resp))))
+        (is (= 200 (:status (deref resp 1000 {:status :timeout})))))
       (finally
         (.stop server)))))
 


### PR DESCRIPTION
If async handling gets broken somehow, failing with a timeout message
is preferrable to hanging indefinitely.