### PR TITLE
Remove lein2 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
-lein: lein2
-script: lein2 all do clean, test
+lein: lein
+script: lein all do clean, test
 branches:
   only:
     - master


### PR DESCRIPTION
This appears to be not supported anymore. The default is already set to lein 2