### PR TITLE
clj-http without slingshot

### DIFF
--- a/README.org
+++ b/README.org
@@ -729,8 +729,8 @@ files or =KeyStore= instances.
 
 The client will throw exceptions on, well, exceptional status codes, meaning all
 HTTP responses other than =#{200 201 202 203 204 205 206 207 300 301 302 303
-307}=. clj-http will throw a [[http://github.com/scgilardi/slingshot][Slingshot]] Stone that can be caught by a regular
-=(catch Exception e ...)= or in Slingshot's =try+= block:
+307}=. clj-http will throw an ex-info exception that can be caught by a regular
+=(catch Exception e ...)= or in [[http://github.com/scgilardi/slingshot][Slingshot]]'s =try+= block:
 
 #+BEGIN_SRC clojure
 (client/get "http://example.com/broken")

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
                  [org.apache.httpcomponents/httpmime "4.5.3"]
                  [commons-codec "1.10"]
                  [commons-io "2.5"]
-                 [slingshot "0.12.2"]
                  [potemkin "0.4.3"]]
   :profiles {:dev {:dependencies [;; optional deps
                                   [cheshire "5.7.1"]

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -9,8 +9,7 @@
             [clojure.test :refer :all]
             [cognitect.transit :as transit]
             [ring.util.codec :refer [form-decode-str]]
-            [ring.middleware.nested-params :refer [parse-nested-keys]]
-            [slingshot.slingshot :refer [try+]])
+            [ring.middleware.nested-params :refer [parse-nested-keys]])
   (:import (java.net UnknownHostException)
            (java.io ByteArrayInputStream)
            (org.apache.http HttpEntity)))
@@ -510,12 +509,12 @@
 (deftest throw-type-field
   (let [client (fn [req] {:status 500})
         e-client (client/wrap-exceptions client)]
-    (try+
+    (try
      (e-client {})
-     (catch [:type :clj-http.client/unexceptional-status] _
-       (is true))
-     (catch Object _
-       (is false ":type selector was not caught.")))))
+     (catch Exception e
+      (if (= :clj-http.client/unexceptional-status (:type (ex-data e)))
+       (is true)
+       (is false ":type selector was not caught."))))))
 
 (deftest throw-on-exceptional-async
   (let [client (fn [req respond raise]


### PR DESCRIPTION
I think the less dependency is better. We could throw an ex-info exception using regular `throw` fn & let user choose to use Slingshot if they want. Thought?