### PR TITLE
Update README.md and changelog.org for 3.x.x

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,6 @@
   - [[#overview][Overview]]
   - [[#philosophy][Philosophy]]
 - [[#installation][Installation]]
-- [[#towards-a-300-release][Towards a 3.0.0 release]]
 - [[#quickstart][Quickstart]]
   - [[#head][HEAD]]
   - [[#get][GET]]
@@ -126,30 +125,6 @@ If you need an older version, a 2.x release is also available.
 #+END_SRC
 
 clj-http supports clojure 1.6.0 and higher.
-
-* Towards a 3.0.0 release
-:PROPERTIES:
-:CUSTOM_ID: h-adb56cf4-1034-4d81-965e-880c7315860c
-:END:
-So there is a 2.0 branch which is based on the latest stable version of
-clj-http. Master, on the other hand, is a rewrite of the =core.clj= for the new
-Apache changes (starting with 4.0 I believe) to use non-deprecated methods.
-There are a number of things that need to be accomplished in order for it to be
-releasable in a non-snapshot version (3.0.0+ is already on Clojars)
-
-Here are the tests that need to pass:
-
-- [X] =lein test clj-http.test.client-test :all=
-- [X] =lein test clj-http.test.conn-mgr-test :all=
-- [X] =lein test clj-http.test.cookies-test :all=
-- [X] =lein test clj-http.test.core-test :all=
-- [X] =lein test clj-http.test.headers-test :all=
-- [X] =lein test clj-http.test.links-test :all=
-- [X] =lein test clj-http.test.multipart-test :all=
-- [X] =lein test clj-http.test.util-test :all=
-
-There are still a few tests that are commented out. Any help or PRs is greatly
-appreciated.
 
 * Quickstart
 :PROPERTIES:

--- a/changelog.org
+++ b/changelog.org
@@ -10,6 +10,26 @@
 * Changelog
 List of user-visible changes that have gone into each release
 
+** 3.7.0
+This list contains all the changes since 3.0.0.
+
+Added:
+- HttpRequestInterceptor support 155bd23
+- protocol-version and reason-phrase f430517
+- support for async HTTP requests (like Ring) 44d10ec
+- support for different multi-param encoding (:repeating, :array, :indexed) cddeb3e
+- Add unparse function aec7dd1
+- Added :redirect-strategy :graceful
+- Allow RequestConfig and HttpClientContext to be injected feb3c48
+
+Removed:
+- :save-request
+
+Changed:
+- re-written middleware using apache http client 4.5
+- Fix retry-handler to be added in correct place a2c31f5
+- POST Mutipart: Use charset "UTF-8" instead of "ASCII" as default charset to support internationalization 983508f
+
 ** 2.0.0
 - merged https://github.com/dakrone/clj-http/pull/274 to update Potemkin so it
   supports Clojure 1.7.0 correctly


### PR DESCRIPTION
Updates the README to remove the 3.0.0 WIP notes.

Added a changelog entry for 3.7.0 containing the changes I was able to decipher from the history.

Fixes #319 