### PR TITLE
create-multipart-entity with two arguments arity lets the selection of HttpMultipartMode

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -13,6 +13,7 @@ List of user-visible changes that have gone into each release
 ** 4.0.0 (Unreleased)
 - Removed slingshot dependency. clj-http exceptions are now regular exceptions
 - Removed deprecated :follow-redirects & :force-redirects options
+- create-multipart-entity with two arguments arity lets the selection of HttpMultipartMode
 
 ** 3.8.0
 Added:

--- a/changelog.org
+++ b/changelog.org
@@ -14,6 +14,7 @@ List of user-visible changes that have gone into each release
 - Removed slingshot dependency. clj-http exceptions are now regular exceptions
 - Removed deprecated :follow-redirects & :force-redirects options
 - create-multipart-entity with two arguments arity lets the selection of HttpMultipartMode
+- new request key :http-multipart-mode which is HttpMultipartMode/STRICT by default
 
 ** 3.8.0
 Added:

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -39,7 +39,8 @@
                                             HttpAsyncClients
                                             CloseableHttpAsyncClient)
            (org.apache.http.message BasicHttpResponse)
-           (java.util.concurrent ExecutionException)))
+           (java.util.concurrent ExecutionException)
+           (org.apache.http.entity.mime HttpMultipartMode)))
 
 (defn parse-headers
   "Takes a HeaderIterator and returns a map of names to values.
@@ -375,13 +376,14 @@
 (defn request
   ([req] (request req nil nil))
   ([{:keys [body conn-timeout conn-request-timeout connection-manager
-            cookie-store cookie-policy headers multipart query-string
-            redirect-strategy max-redirects retry-handler
+            cookie-store cookie-policy headers multipart http-multipart-mode
+            query-string redirect-strategy max-redirects retry-handler
             request-method scheme server-name server-port socket-timeout
             uri response-interceptor proxy-host proxy-port async?
             http-client-context http-request-config
             proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth]
-     :as req} respond raise]
+     :or   {http-multipart-mode HttpMultipartMode/STRICT}
+     :as   req} respond raise]
    (let [req (dissoc req :async?)
          scheme (name scheme)
          http-url (str scheme "://" server-name
@@ -423,7 +425,7 @@
             (.setCredentials authscope creds)))))
      (if multipart
        (.setEntity ^HttpEntityEnclosingRequest http-req
-                   (mp/create-multipart-entity multipart))
+                   (mp/create-multipart-entity multipart http-multipart-mode))
        (when (and body (instance? HttpEntityEnclosingRequest http-req))
          (if (instance? HttpEntity body)
            (.setEntity ^HttpEntityEnclosingRequest http-req body)

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -128,12 +128,14 @@
 (defn create-multipart-entity
   "Takes a multipart vector of maps and creates a MultipartEntity with each
   map added as a part, depending on the type of content."
-  [multipart]
-  (let [mp-entity (MultipartEntity. HttpMultipartMode/STRICT
-                                    nil
-                                    (encoding-to-charset "UTF-8"))]
-    (doseq [m multipart]
-      (let [name (or (:part-name m) (:name m))
-            part (make-multipart-body m)]
-        (.addPart mp-entity name part)))
-    mp-entity))
+  ([multipart]
+    (create-multipart-entity multipart HttpMultipartMode/STRICT))
+  ([multipart multipart-mode]
+   (let [mp-entity (MultipartEntity. multipart-mode
+                                     nil
+                                     (encoding-to-charset "UTF-8"))]
+     (doseq [m multipart]
+       (let [name (or (:part-name m) (:name m))
+             part (make-multipart-body m)]
+         (.addPart mp-entity name part)))
+     mp-entity)))


### PR DESCRIPTION
Any HttpMultipartMode modes should be selectable. In particular, HttpMultipartMode/RFC6532 was needed for mailgun compatibility.