### PR TITLE
add a :mime-subtype request parameter to override the multipart subtype

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -423,7 +423,7 @@
             (.setCredentials authscope creds)))))
      (if multipart
        (.setEntity ^HttpEntityEnclosingRequest http-req
-                   (mp/create-multipart-entity multipart))
+                   (mp/create-multipart-entity multipart req))
        (when (and body (instance? HttpEntityEnclosingRequest http-req))
          (if (instance? HttpEntity body)
            (.setEntity ^HttpEntityEnclosingRequest http-req body)

--- a/src/clj_http/core_old.clj
+++ b/src/clj_http/core_old.clj
@@ -285,7 +285,7 @@
           (.addHeader http-req header-n (str header-v))))
       (if multipart
         (.setEntity ^HttpEntityEnclosingRequest http-req
-                    (mp/create-multipart-entity multipart))
+                    (mp/create-multipart-entity multipart req))
         (when (and body (instance? HttpEntityEnclosingRequest http-req))
           (if (instance? HttpEntity body)
             (.setEntity ^HttpEntityEnclosingRequest http-req body)

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -2,7 +2,7 @@
   "Namespace used for clj-http to create multipart entities and bodies."
   (:import (java.io File InputStream)
            (org.apache.http.entity ContentType)
-           (org.apache.http.entity.mime MultipartEntity)
+           (org.apache.http.entity.mime MultipartEntityBuilder)
            (org.apache.http.entity.mime HttpMultipartMode)
            (org.apache.http.entity.mime.content ContentBody
                                                 ByteArrayBody
@@ -128,12 +128,13 @@
 (defn create-multipart-entity
   "Takes a multipart vector of maps and creates a MultipartEntity with each
   map added as a part, depending on the type of content."
-  [multipart]
-  (let [mp-entity (MultipartEntity. HttpMultipartMode/STRICT
-                                    nil
-                                    (encoding-to-charset "UTF-8"))]
+  [multipart {:keys [mime-subtype]}]
+  (let [mp-entity (doto (MultipartEntityBuilder/create)
+                    (.setStrictMode)
+                    (.setCharset (encoding-to-charset "UTF-8"))
+                    (.setMimeSubtype (or mime-subtype "form-data")))]
     (doseq [m multipart]
       (let [name (or (:part-name m) (:name m))
             part (make-multipart-body m)]
         (.addPart mp-entity name part)))
-    mp-entity))
+    (.build mp-entity)))


### PR DESCRIPTION
This feature has been in HTTPClient since 2014 but clj-http does not have support for it.  As a result, it is impossible to make e.g. multipart/mixed requests with clj-http (unless you construct the body and header yourself).