### PR TITLE
Updated SSLGenericSocketFactory to accept an empty context

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -56,13 +56,14 @@
   "Given a function that returns a new socket, create an
   SSLConnectionSocketFactory that will use that socket."
   ([socket-factory]
-   (SSLGenericSocketFactory socket-factory (SSLContexts/createDefault)))
+   (SSLGenericSocketFactory socket-factory nil))
   ([socket-factory ^SSLContext ssl-context]
-   (proxy [SSLConnectionSocketFactory] [ssl-context]
-     (connectSocket [timeout socket host remoteAddress localAddress context]
-       (let [^SSLConnectionSocketFactory this this] ;; avoid reflection
-         (proxy-super connectSocket timeout (socket-factory) host remoteAddress
-                      localAddress context))))))
+   (let [^SSLContext ssl-context' (or ssl-context (SSLContexts/createDefault))]
+     (proxy [SSLConnectionSocketFactory] [ssl-context']
+       (connectSocket [timeout socket host remoteAddress localAddress context]
+         (let [^SSLConnectionSocketFactory this this] ;; avoid reflection
+           (proxy-super connectSocket timeout (socket-factory) host remoteAddress
+                        localAddress context)))))))
 
 (defn ^PlainConnectionSocketFactory PlainGenericSocketFactory
   "Given a Function that returns a new socket, create a


### PR DESCRIPTION
See issue #425.

Chose to accept a nil argument to `SSLGenericSocketFactory`, so as to avoid changing the function interface that is implied in `make-socks-proxied-conn-manager`.

Using a `let` block to create the argument for the proxy, so that it's set outside of the call to a macro.