### PR TITLE
Update list of unexceptional statuses in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -451,7 +451,7 @@ All exceptions thrown during the request will be passed to the raise callback.
 Output coercion with =:as :json=, =:as :json-strict=, =:as :json-strict-string-keys=, =:as :json-string-keys= or =:as :x-www-form-urlencoded= will only work with an optional dependency, see [[#optional-dependencies][Optional Dependencies]].
 
 JSON coercion defaults to only an "unexceptional" statuses, meaning status codes
-in the #{200 201 202 203 204 205 206 207 300 301 302 303 307} range. If you
+in the #{200 201 202 203 204 205 206 207 300 301 302 303 304 307} range. If you
 would like to change this, you can send the =:coerce= option, which can be set
 to:
 
@@ -711,7 +711,7 @@ files or =KeyStore= instances.
 :END:
 
 The client will throw exceptions on, well, exceptional status codes, meaning all
-HTTP responses other than =#{200 201 202 203 204 205 206 207 300 301 302 303
+HTTP responses other than =#{200 201 202 203 204 205 206 207 300 301 302 303 304
 307}=. clj-http will throw an ex-info exception that can be caught by a regular
 =(catch Exception e ...)= or in [[http://github.com/scgilardi/slingshot][Slingshot]]'s =try+= block:
 


### PR DESCRIPTION
Was probably missed when doing [this](https://github.com/dakrone/clj-http/commit/64a3520f8b6de396c9fa49244b037178a68a70b7) change.