### PR TITLE
Addressing a problem with 404 errors for EDN requests

### DIFF
--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1148,6 +1148,13 @@
            (:body (client/coerce-response-body {:as :x-www-form-urlencoded}
                                                www-form-urlencoded-resp))))))
 
+(deftest t-coercion-method-error
+  (let [edn-body (ByteArrayInputStream. (.getBytes "error: not found"))
+        edn-resp {:body edn-body :status 404
+                  :headers {"content-type" "application/edn"}}]
+    (is (= "error: not found"
+           (:body (client/coerce-response-body {:as :clojure} edn-resp))))))
+
 (deftest ^:integration t-with-middleware
   (run-server)
   (is (:request-time (request {:uri "/get" :method :get})))


### PR DESCRIPTION
Regardless of the requested content type, if an error occurs (such as 404) then the server will often return HTML or plain text to indicate the error. If EDN is requested and status code exceptions turned off, then the returned data is parsed as EDN, leading to a parse exception, and the status is lost.

This patch allows successful EDN requests to go through standard parsing with no change. Unsuccessful requests will attempt to parse EDN (just in case the server really is trying to return a data structure... something I've yet to encounter), but if an error is encountered, it returns the body as raw text.