### PR TITLE
 Add options for how to flatten/encode form and query parameters

### DIFF
--- a/README.org
+++ b/README.org
@@ -339,6 +339,19 @@ content encodings.
                                                     (if (> try-count 4) false true))})
 #+END_SRC
 
+A word about flattening nested =:query-params= and =:form-params= maps. There are essentially three
+different ways to handle flattening them:
+
+- =:ignore-nested-query-string= :: Do not handle nested query parameters specially, treat them as
+     the exact text they come in as. Defaults to *false*.
+- =:flatten-nested-form-params= :: Flatten nested (map within a map) =:form-params= before encoding
+     it as the body. Defaults to *false*, meaning form params are encoded only
+     =x-www-form-urlencoded=.
+- =:flatten-nested-keys= :: An advanced way of specifying which keys having nested maps should be
+     flattened. A middleware function checks the previous two options
+     (=:ignore-nested-query-string= and =:flatten-nested-form-params=) and modifies this to be the
+     list that will be flattened.
+
 ** DELETE
 :PROPERTIES:
 :CUSTOM_ID: h-c7165d6b-232a-439d-9390-8c05e6ef1e6f

--- a/changelog.org
+++ b/changelog.org
@@ -13,14 +13,17 @@ List of user-visible changes that have gone into each release
 ** 4.0.0 (Unreleased)
 - Removed slingshot dependency. clj-http exceptions are now regular exceptions
 - Removed deprecated :follow-redirects & :force-redirects options
-- Wrap nested querystring params before form params, fixing
-  https://github.com/dakrone/clj-http/issues/427
+- +Wrap nested querystring params before form params, fixing
+  https://github.com/dakrone/clj-http/issues/427+ Reverted, see further below
 - Merged https://github.com/dakrone/clj-http/pull/426 to allow an empty SSLGenericSocketFactory
   context
 - Merged https://github.com/dakrone/clj-http/pull/424 to add :mime-subtype request parameter to
   override mime subtype
 - create-multipart-entity with three arguments arity lets the selection of =HttpMultipartMode=
 - new request key :http-multipart-mode which is HttpMultipartMode/STRICT by default
+- Added =:ignore-nested-query-string=, =:flatten-nested-form-params=, and =:flatten-nested-keys=
+  options for finer-grained control over which nested parts of the request are flattened. Fixes
+  https://github.com/dakrone/clj-http/issues/427
 
 ** 3.8.0
 - Reintroduce the =:save-request= and =:debug-body= options

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -881,11 +881,15 @@
      (client (nest-params-request req) respond raise))))
 
 (defn- nested-keys-to-flatten
-  [{:keys [flatten-nested-keys
-           ignore-nested-query-string
-           flatten-nested-form-params]}]
-  (let [iqs-key (when-not ignore-nested-query-string :query-params)
-        ifp-key (when flatten-nested-form-params :form-params)]
+  [{:keys [flatten-nested-keys] :as req}]
+  (when (and (not (nil? (opt req :ignore-nested-query-string)))
+             (not (nil? (opt req :flatten-nested-form-params)))
+             flatten-nested-keys)
+    (throw (IllegalArgumentException.
+            (str "only :flatten-nested-keys or :ignore-nested-query-string/"
+                 ":flatten-nested-keys may be specified, not both"))))
+  (let [iqs-key (when-not (opt req :ignore-nested-query-string) :query-params)
+        ifp-key (when (opt req :flatten-nested-form-params) :form-params)]
     (or flatten-nested-keys
         (remove nil? (list iqs-key ifp-key)))))
 

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -921,7 +921,7 @@
                 (fn [req] {:body nil})) {:decode-body-headers true})
         resp4 ((client/wrap-additional-header-parsing
                 (fn [req] {:headers {"content-type" "application/pdf"}
-                           :body (.getBytes text)}))
+                          :body (.getBytes text)}))
                {:decode-body-headers true})]
     (is (= {"content-type" "text/html; charset=Shift_JIS"
             "content-style-type" "text/css"
@@ -1261,3 +1261,31 @@
       (is (= 200 (:status resp)))
       (is (.contains query-string "a[]=1&a[]=2&a[]=3") query-string)
       (is (.contains query-string "b[]=x&b[]=y&b[]=z") query-string))))
+
+(deftest t-wrap-flatten-nested-params
+  (is-applied client/wrap-flatten-nested-params
+              {}
+              {:flatten-nested-keys [:query-params]})
+  (is-applied client/wrap-flatten-nested-params
+              {:flatten-nested-keys []}
+              {:flatten-nested-keys []})
+  (is-applied client/wrap-flatten-nested-params
+              {:flatten-nested-keys [:foo]}
+              {:flatten-nested-keys [:foo]})
+  (is-applied client/wrap-flatten-nested-params
+              {:ignore-nested-query-string true}
+              {:ignore-nested-query-string true
+               :flatten-nested-keys []})
+  (is-applied client/wrap-flatten-nested-params
+              {}
+              {:flatten-nested-keys '(:query-params)})
+  (is-applied client/wrap-flatten-nested-params
+              {:flatten-nested-form-params true}
+              {:flatten-nested-form-params true
+               :flatten-nested-keys '(:query-params :form-params)})
+  (is-applied client/wrap-flatten-nested-params
+              {:flatten-nested-form-params true
+               :ignore-nested-query-string true}
+              {:ignore-nested-query-string true
+               :flatten-nested-form-params true
+               :flatten-nested-keys '(:form-params)}))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1288,4 +1288,13 @@
                :ignore-nested-query-string true}
               {:ignore-nested-query-string true
                :flatten-nested-form-params true
-               :flatten-nested-keys '(:form-params)}))
+               :flatten-nested-keys '(:form-params)})
+  (try
+    ((client/wrap-flatten-nested-params identity)
+     {:flatten-nested-form-params true
+      :ignore-nested-query-string true
+      :flatten-nested-keys [:thing :bar]})
+    (catch IllegalArgumentException e
+      (is (= (.getMessage e)
+             (str "only :flatten-nested-keys or :ignore-nested-query-string/"
+                  ":flatten-nested-keys may be specified, not both"))))))


### PR DESCRIPTION
This adds the following new parameters:

- `:ignore-nested-query-string` :: Do not handle nested query parameters specially, treat them as
     the exact text they come in as. Defaults to *false*.
- `:flatten-nested-form-params` :: Flatten nested (map within a map) `:form-params` before encoding
     it as the body. Defaults to *false*, meaning form params are encoded only
     `x-www-form-urlencoded`.
- `:flatten-nested-keys` :: An advanced way of specifying which keys having nested maps should be
     flattened. A middleware function checks the previous two options
     (`:ignore-nested-query-string` and `:flatten-nested-form-params`) and modifies this to be the
     list that will be flattened.

Resolves #427