### PR TITLE
Add ability to specify arbitrary functions to modify http client builders

### DIFF
--- a/README.org
+++ b/README.org
@@ -1062,6 +1062,34 @@ which is a vector of the default middleware that clj-http uses.
 =clj-http.client/*current-middleware*= is bound to the current list of
 middleware during request time.
 
+** Modifying Apache-specific features of the =HttpClientBuilder= and =HttpAsyncClientBuilder=
+:PROPERTIES:
+:CUSTOM_ID: h:844f078c-531e-445e-b7ce-76092bcc9928
+:END:
+
+While clj-http tries to provide the features needed, there are times when it does not provide access
+to a parameter that you need. In these cases, you can use a couple of advanced parameters to provide
+arbitrary configuration functions to be run on the =HttpClientBuilder= by specifying
+=:http-builder-fns= and =:async-http-builder-fns=.
+
+Each of these variables is a sequence of functions of two arguments, the http builder
+(=HttpClientBuilder= for =:http-builder-fns= and =HttpAsyncClientBuilder= for
+=:async-http-builder-fns=) and the request map.
+
+#+BEGIN_SRC clojure
+;; A function that takes a builder and disables Apache's cookie management
+(defun my-cookie-disabler [^HttpClientBuilder builder
+                           request]
+  (when (:disable-cookies request)
+    (.disableCookieManagement builder)))
+
+;; The functions to modify the builder are passed in
+(http/post "http://www.example.org" {:http-builder-fns [my-cookie-disabler]
+                                     :disable-cookies true})
+#+END_SRC
+
+The functions are run in the order they are passed in (inside a =doseq=).
+
 * Development
 :PROPERTIES:
 :CUSTOM_ID: h-65bbf017-2e8b-4c43-824b-24b89cc27a70

--- a/changelog.org
+++ b/changelog.org
@@ -24,6 +24,8 @@ List of user-visible changes that have gone into each release
 - Added =:ignore-nested-query-string=, =:flatten-nested-form-params=, and =:flatten-nested-keys=
   options for finer-grained control over which nested parts of the request are flattened. Fixes
   https://github.com/dakrone/clj-http/issues/427
+- Added =:http-builder-fns= and =:async-http-builder-fns= to support arbitrary customizations to the
+  =HttpClientBuilder= and =HttpAsyncClientBuilder=
 
 ** 3.8.0
 - Reintroduce the =:save-request= and =:debug-body= options

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -256,7 +256,7 @@
 
 (defn- respond*
   [resp req]
-  (if (:async? req)
+  (if (opt req :async)
     ((:respond req) resp)
     resp))
 
@@ -1096,8 +1096,8 @@
      (throw (IllegalArgumentException. "Host URL cannot be nil"))))
 
 (defn- request*
-  [{:keys [async?] :as req} [respond raise]]
-  (if async?
+  [req [respond raise]]
+  (if (opt req :async)
     (if (some nil? [respond raise])
       (throw (IllegalArgumentException.
               "If :async? is true, you must pass respond and raise"))


### PR DESCRIPTION
This adds the `:http-builder-fns` and `:async-http-builder-fns` options to
specify an arbitrary sequence of functions that can be used to modify the
`HttpClientBuilder` and `HttpAsyncClientBuilder` objects before the request is
sent.

Relates to #390