### PR TITLE
Add custom `:unexceptional-status` option

### DIFF
--- a/README.org
+++ b/README.org
@@ -828,6 +828,8 @@ HTTP responses other than =#{200 201 202 203 204 205 206 207 300 301 302 303 304
 ;; Or ignore an unknown host (methods return 'nil' if this is set to
 ;; true and the host does not exist:
 (client/get "http://example.invalid" {:ignore-unknown-host? true})
+;; Or customize the http statuses that will throw:
+(client/get "http://example.com/broken" {:unexceptional-status #(<= 200 % 299)})
 #+END_SRC
 
 (spacing added by me to be human readable)

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -204,6 +204,10 @@
 (def unexceptional-status?
   #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})
 
+(defn unexceptional-status-for-request?
+  [req status]
+  ((:unexceptional-status req unexceptional-status?) status))
+
 ;; helper methods to determine realm of a response
 (defn success?
   [{:keys [status]}]
@@ -231,7 +235,7 @@
 
 (defn- exceptions-response
   [req {:keys [status] :as resp}]
-  (if (unexceptional-status? status)
+  (if (unexceptional-status-for-request? req status)
     resp
     (if (false? (opt req :throw-exceptions))
       resp
@@ -433,7 +437,8 @@
           (assoc resp :body (ByteArrayInputStream. body)))))
 
 (defn coerce-json-body
-  [{:keys [coerce]} {:keys [body status] :as resp} keyword? strict? & [charset]]
+  [{:keys [coerce] :as request}
+   {:keys [body status] :as resp} keyword? strict? & [charset]]
   (let [^String charset (or charset (-> resp :content-type-params :charset)
                             "UTF-8")
         body (util/force-byte-array body)
@@ -443,11 +448,12 @@
         (= coerce :always)
         (assoc resp :body (decode-func (String. ^"[B" body charset) keyword?))
 
-        (and (unexceptional-status? status)
+        (and (unexceptional-status-for-request? request status)
              (or (nil? coerce) (= coerce :unexceptional)))
         (assoc resp :body (decode-func (String. ^"[B" body charset) keyword?))
 
-        (and (not (unexceptional-status? status)) (= coerce :exceptional))
+        (and (not (unexceptional-status-for-request? request status))
+             (= coerce :exceptional))
         (assoc resp :body (decode-func (String. ^"[B" body charset) keyword?))
 
         :else (assoc resp :body (String. ^"[B" body charset)))
@@ -476,12 +482,13 @@
           (assoc resp :body (parse-transit
                              (ByteArrayInputStream. body) type transit-opts))
 
-          (and (unexceptional-status? status)
+          (and (unexceptional-status-for-request? request status)
                (or (nil? coerce) (= coerce :unexceptional)))
           (assoc resp :body (parse-transit
                              (ByteArrayInputStream. body) type transit-opts))
 
-          (and (not (unexceptional-status? status)) (= coerce :exceptional))
+          (and (not (unexceptional-status-for-request? request status))
+               (= coerce :exceptional))
           (assoc resp :body (parse-transit
                              (ByteArrayInputStream. body) type transit-opts))
 

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -525,6 +525,12 @@
     (is (thrown-with-msg? Exception #":body"
                           (e-client {:throw-entire-message? true})))))
 
+(deftest throw-on-custom-exceptional
+  (let [client (fn [req] {:status 201})
+        e-client (client/wrap-exceptions client)]
+    (is (thrown-with-msg? Exception #"201"
+                          (e-client {:unexceptional-status #{200}})))))
+
 (deftest throw-type-field
   (let [client (fn [req] {:status 500})
         e-client (client/wrap-exceptions client)]
@@ -564,6 +570,12 @@
         e-client (client/wrap-exceptions client)
         resp (e-client {})]
     (is (= 200 (:status resp)))))
+
+(deftest pass-on-custom-non-exceptional
+  (let [client (fn [req] {:status 500})
+        e-client (client/wrap-exceptions client)
+        resp (e-client {:unexceptional-status #{200 500}})]
+    (is (= 500 (:status resp)))))
 
 (deftest pass-on-non-exceptional-async
   (let [client (fn [req respond raise] (respond {:status 200}))


### PR DESCRIPTION
I have come across a couple of cases where I need to customize which http status codes are considered exceptional but don't need to do anything else with the response. This PR allows passing a custom `:unexceptional-status` function in the request, as a way to handle these cases (instead of passing `{:throw-exceptions false}` and handling exceptions yourself).