### PR TITLE
Resolve reflection warnings

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -100,7 +100,7 @@
 
 (defn ^:dynamic parse-transit
   "Resolve and apply Transit's JSON/MessagePack decoding."
-  [in type & [opts]]
+  [^InputStream in type & [opts]]
   {:pre [transit-enabled?]}
   (when (pos? (.available in))
     (let [reader (ns-resolve 'cognitect.transit 'reader)

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -194,7 +194,7 @@
       (.setSocketConfig conn-manager
                         (-> (.getSocketConfig conn-manager)
                             (SocketConfig/copy)
-                            (.setSocketTimeout socket-timeout) ;modify only the socket-timeout
+                            (.setSoTimeout socket-timeout) ;modify only the socket-timeout
                             (.build))))
     conn-manager))
 

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -313,21 +313,21 @@
    & [http-url proxy-ignore-hosts]]
   ;; have to let first, otherwise we get a reflection warning on (.build)
   (let [cache? (opt req :cache)
-        ^HttpClientBuilder builder (-> (if caching?
-                                         (CachingHttpClientBuilder/create)
-                                         (HttpClients/custom))
-                                       (.setConnectionManager conn-mgr)
-                                       (.setRedirectStrategy
-                                        (get-redirect-strategy req))
-                                       (add-retry-handler retry-handler)
-                                       ;; By default, get the proxy settings
-                                       ;; from the jvm or system properties
-                                       (.setRoutePlanner
-                                        (get-route-planner
-                                         proxy-host proxy-port
-                                         proxy-ignore-hosts http-url)))]
+        builder (-> (if caching?
+                      ^HttpClientBuilder (CachingHttpClientBuilder/create)
+                      ^HttpClientBuilder (HttpClients/custom))
+                    (.setConnectionManager conn-mgr)
+                    (.setRedirectStrategy
+                     (get-redirect-strategy req))
+                    (add-retry-handler retry-handler)
+                    ;; By default, get the proxy settings
+                    ;; from the jvm or system properties
+                    (.setRoutePlanner
+                     (get-route-planner
+                      proxy-host proxy-port
+                      proxy-ignore-hosts http-url)))]
     (when cache?
-      (.setCacheConfig builder (build-cache-config req)))
+      (.setCacheConfig ^CachingHttpClientBuilder builder (build-cache-config req)))
     (when (or cookie-policy-registry cookie-spec)
       (if cookie-policy-registry
         ;; They have a custom registry they'd like to re-use, so use that
@@ -519,7 +519,7 @@
          :reason-phrase (.getReasonPhrase status)
          :trace-redirects (mapv str (.getRedirectLocations context))
          :cached (when (instance? HttpCacheContext context)
-                   (when-let [cache-resp (.getCacheResponseStatus context)]
+                   (when-let [cache-resp (.getCacheResponseStatus ^HttpCacheContext context)]
                      (-> cache-resp str keyword)))}]
     (if (opt req :save-request)
       (-> response

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -25,12 +25,12 @@
 (defn url-decode
   "Returns the form-url-decoded version of the given string, using either a
   specified encoding or UTF-8 by default."
-  [encoded & [encoding]]
+  [^String encoded & [^String encoding]]
   (URLDecoder/decode encoded (or encoding "UTF-8")))
 
 (defn url-encode
   "Returns an UTF-8 URL encoded version of the given string."
-  [unencoded & [encoding]]
+  [^String unencoded & [^String encoding]]
   (URLEncoder/encode unencoded (or encoding "UTF-8")))
 
 (defn base64-encode
@@ -64,7 +64,7 @@
   (if (instance? java.io.InputStream b)
     (try
       (let [^int first-byte (try
-                              (.read b)
+                              (.read ^java.io.InputStream b)
                                (catch EOFException e -1))]
         (if (= -1 first-byte)
           (byte-array 0)


### PR DESCRIPTION
Resolves a couple of the reflection warnings I get when using `clj-http`.

This is split into 2 commits, as the change in `conn_mgr` is somewhat more serious, but given that I both the compiler and I think that it is trying to call a method on a `SocketConfig.Builder` at that point in the code which doesn't have a `setSocketTimeout` but does have a `setSoTimeout` I believe this is the appropriate change.

EDIT: Forgot to mention it doesn't change the set of tests that fail/error out here.