### PR TITLE
Add trust-managers, key-managers support to client

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -121,7 +121,8 @@
     :as req}]
   (let [x-or-xs->x-array (fn [type x-or-xs]
                            (cond
-                             (seqable? x-or-xs)
+                             (or (-> x-or-xs .getClass .isArray)
+                                 (sequential? x-or-xs))
                              (into-array type (seq x-or-xs))
 
                              :else

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -121,7 +121,7 @@
     :as req}]
   (let [x-or-xs->x-array (fn [type x-or-xs]
                            (cond
-                             (or (-> x-or-xs .getClass .isArray)
+                             (or (-> x-or-xs class .isArray)
                                  (sequential? x-or-xs))
                              (into-array type (seq x-or-xs))
 


### PR DESCRIPTION
This is a PR that supports adding TrustManagers and KeyManagers to the clj-http client.
While keystore and trust-store options allow us to pin leaf certificates, letting us use TLS/SSL certificates without CA validation, there are forms of pinning that aren't supported by keystores and trust-stores alone.
One such form of pinning not supported by keystore is called Public Key Pinning. Given a public key from some certificate, we can tell the client to only connections from hosts in possession of the corresponding private key.
This allows us to continue trusting certificates from some server even after a new leaf certificate has been issued as long as the host's private key remains the same (no CA validation required).
Instead of having to replace the client keystore every time a Certificate changes or expires, we'd only need to replace the TrustManager in the case that the Certificate issuer's private key changes.
Furthermore, TrustManagers and KeyManagers allow one to compose KeyStores in ways not currently possible passing in a single KeyStore as a trust-store or keystore.
In terms of the reason I am adding this to clj-http is for the client to support public key pinning.
