### PR TITLE
create async registry when making reusable async connection manager

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -298,7 +298,7 @@
                    (opt config :insecure) @insecure-strategy-registry
 
                    (or keystore trust-store)
-                   (get-keystore-scheme-registry config)
+                   (get-keystore-strategy-registry config)
 
                    :else regular-strategy-registry)
         io-reactor (make-ioreactor io-config)


### PR DESCRIPTION
Hi, this looks like a straightforward bug. Now it is creating the same registry as is used for a non-reusable async manager. 