### PR TITLE
Do not specify charset for multipart requests

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -131,7 +131,6 @@
   [multipart {:keys [mime-subtype]}]
   (let [mp-entity (doto (MultipartEntityBuilder/create)
                     (.setStrictMode)
-                    (.setCharset (encoding-to-charset "UTF-8"))
                     (.setMimeSubtype (or mime-subtype "form-data")))]
     (doseq [m multipart]
       (let [name (or (:part-name m) (:name m))

--- a/test/clj_http/test/multipart_test.clj
+++ b/test/clj_http/test/multipart_test.clj
@@ -2,9 +2,10 @@
   (:require [clj-http.multipart :refer :all]
             [clojure.test :refer :all])
   (:import (java.io File ByteArrayOutputStream ByteArrayInputStream)
+           (java.nio.charset Charset)
            (org.apache.http.entity.mime.content FileBody StringBody ContentBody
                                                 ByteArrayBody InputStreamBody)
-           (java.nio.charset Charset)))
+           (org.apache.http.util EntityUtils)))
 
 (defn body-str [^StringBody body]
   (-> body .getReader slurp))
@@ -173,3 +174,8 @@
         (is (= (Charset/forName "ascii") (body-charset body)))
         (is (= test-file (.getFile body) ))
         (is (= "testname" (.getFilename body)))))))
+
+(deftest test-multipart-content-charset
+  (testing "charset is nil for all multipart requests"
+    (let [mp-entity (create-multipart-entity [] nil)]
+      (is (nil? (EntityUtils/getContentCharSet mp-entity))))))


### PR DESCRIPTION
Details in the following issue: https://github.com/dakrone/clj-http/issues/472