### PR TITLE
Fix NPE for `unexceptional-status-for-request?`

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -206,7 +206,8 @@
 
 (defn unexceptional-status-for-request?
   [req status]
-  ((:unexceptional-status req unexceptional-status?) status))
+  ((or (:unexceptional-status req) unexceptional-status?)
+   status))
 
 ;; helper methods to determine realm of a response
 (defn success?


### PR DESCRIPTION
Fixes `(unexceptional-status-for-request? {:unexceptional-status nil} 200) => NPE`. I.e. if you have no `:unexceptional-status` key, this will work fine, but if this key is present then `nil` will be used as fn