### PR TITLE
Reduce body allocation and copying

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -62,18 +62,13 @@
   "force b as byte array if it is an InputStream, also close the stream"
   ^bytes [b]
   (if (instance? java.io.InputStream b)
-    (try
-      (let [^int first-byte (try
-                              (.read ^java.io.InputStream b)
-                               (catch EOFException e -1))]
-        (if (= -1 first-byte)
-          (byte-array 0)
-          (let [rest-bytes (IOUtils/toByteArray ^java.io.InputStream b)
-                barray (byte-array (inc (count rest-bytes)))]
-            (aset-byte barray 0 (unchecked-byte first-byte))
-            (System/arraycopy rest-bytes 0 barray 1 (count rest-bytes))
-            barray)))
-      (finally (.close ^java.io.InputStream b)))
+    (let [^java.io.InputStream bs b]
+      (try
+        (IOUtils/toByteArray bs)
+        (catch EOFException _
+          (byte-array 0))
+        (finally
+          (.close bs))))
     b))
 
 (def ^:private ByteArray (Class/forName "[B"))

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -76,6 +76,15 @@
       (finally (.close ^java.io.InputStream b)))
     b))
 
+(def ^:private ByteArray (Class/forName "[B"))
+
+(defn force-stream
+  "Force b as InputStream if it is a ByteArray."
+  ^java.io.InputStream [b]
+  (if (instance? ByteArray b)
+    (ByteArrayInputStream. b)
+    b))
+
 (defn inflate
   "Returns a zlib inflate'd version of the given byte array or InputStream."
   [b]


### PR DESCRIPTION
Removes various intermediate byte arrays and strings in body decoding that were unnecessary. JSON and Transit decoding get the most benefit.

I didn't have time to figure out every format and it seems that some of them would need changes to other libraries like `ring.util.codec`. https://github.com/dakrone/cheshire/pull/139 would also enable a bit more gains for JSON decoding.