### PR TITLE
Use consistent connection option names

### DIFF
--- a/README.org
+++ b/README.org
@@ -268,7 +268,7 @@ Example requests:
 (client/get "http://example.com/redirects-somewhere" {:max-redirects 5 :redirect-strategy :graceful})
 
 ;; Throw an exception if the get takes too long. Timeouts in milliseconds.
-(client/get "http://example.com/redirects-somewhere" {:socket-timeout 1000 :conn-timeout 1000})
+(client/get "http://example.com/redirects-somewhere" {:socket-timeout 1000 :connection-timeout 1000})
 
 ;; Query parameters
 (client/get "http://example.com/search" {:query-params {"q" "foo, bar"}})
@@ -325,8 +325,8 @@ content encodings.
               :body "{\"json\": \"input\"}"
               :headers {"X-Api-Version" "2"}
               :content-type :json
-              :socket-timeout 1000  ;; in milliseconds
-              :conn-timeout 1000    ;; in milliseconds
+              :socket-timeout 1000      ;; in milliseconds
+              :connection-timeout 1000  ;; in milliseconds
               :accept :json})
 
 ;; Send form params as a urlencoded body (POST or PUT)

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -179,17 +179,20 @@
 (defmethod get-cookie-policy :stardard-strict standard-strict-cookie-policy
   [_] CookieSpecs/STANDARD_STRICT)
 
-(defn request-config [{:keys [conn-timeout
+(defn request-config [{:keys [connection-timeout
+                              connection-request-timeout
                               socket-timeout
-                              conn-request-timeout
                               max-redirects
-                              cookie-spec]
+                              cookie-spec
+                              ; deprecated
+                              conn-request-timeout
+                              conn-timeout]
                        :as req}]
   (let [config (-> (RequestConfig/custom)
-                   (.setConnectTimeout (or conn-timeout -1))
+                   (.setConnectTimeout (or connection-timeout conn-timeout -1))
                    (.setSocketTimeout (or socket-timeout -1))
                    (.setConnectionRequestTimeout
-                    (or conn-request-timeout -1))
+                    (or connection-request-timeout conn-request-timeout -1))
                    (.setRedirectsEnabled true)
                    (.setCircularRedirectsAllowed
                     (boolean (opt req :allow-circular-redirects)))
@@ -553,13 +556,15 @@
 
 (defn request
   ([req] (request req nil nil))
-  ([{:keys [body conn-timeout conn-request-timeout connection-manager
+  ([{:keys [body connection-timeout connection-request-timeout connection-manager
             cookie-store cookie-policy headers multipart query-string
             redirect-strategy max-redirects retry-handler
             request-method scheme server-name server-port socket-timeout
             uri response-interceptor proxy-host proxy-port
             http-client-context http-request-config http-client
-            proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth]
+            proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth
+            ; deprecated
+            conn-timeout conn-request-timeout]
      :as req} respond raise]
    (let [async? (opt req :async)
          cache? (opt req :cache)

--- a/src/clj_http/core_old.clj
+++ b/src/clj_http/core_old.clj
@@ -212,10 +212,13 @@
   Note that where Ring uses InputStreams for the request and response bodies,
   the clj-http uses ByteArrays for the bodies."
   [{:keys [request-method scheme server-name server-port uri query-string
-           headers body multipart socket-timeout conn-timeout proxy-host
+           headers body multipart socket-timeout connection-timeout proxy-host
            proxy-ignore-hosts proxy-port proxy-user proxy-pass as cookie-store
            retry-handler response-interceptor digest-auth ntlm-auth
-           connection-manager client-params]
+           connection-manager client-params
+           ; deprecated
+           conn-timeout
+           ]
     :as req}]
   (let [^ClientConnectionManager conn-mgr
         (or connection-manager
@@ -237,7 +240,8 @@
      ;; merge in map of specified timeouts, to
      ;; support backward compatibility.
      (merge {CoreConnectionPNames/SO_TIMEOUT socket-timeout
-             CoreConnectionPNames/CONNECTION_TIMEOUT conn-timeout}
+             CoreConnectionPNames/CONNECTION_TIMEOUT (or connection-timeout
+                                                         conn-timeout)}
             client-params))
 
     (when-let [[user pass] digest-auth]

--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -156,7 +156,7 @@
                      :server-name "localhost"
                      ;; timeouts forces an exception being thrown
                      :socket-timeout 1
-                     :conn-timeout 1
+                     :connection-timeout 1
                      :connection-manager cm
                      :as :stream})
       (is false "request should have thrown an exception")

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -605,7 +605,7 @@
 
 ;; This relies on connections to writequit.org being slower than 10ms, if this
 ;; fails, you must have very nice internet.
-(deftest ^:integration sets-conn-timeout
+(deftest ^:integration sets-connection-timeout
   (run-server)
   (try
     (is (thrown? SocketTimeoutException
@@ -613,7 +613,7 @@
                                   :server-name "writequit.org"
                                   :server-port 80
                                   :request-method :get :uri "/"
-                                  :conn-timeout 10})))))
+                                  :connection-timeout 10})))))
 
 (deftest ^:integration connection-pool-timeout
   (run-server)
@@ -622,8 +622,8 @@
                                                   :server-name "localhost"
                                                   :server-port 18080
                                                   :request-method :get
-                                                  :conn-timeout 1
-                                                  :conn-request-timeout 1
+                                                  :connection-timeout 1
+                                                  :connection-request-timeout 1
                                                   :uri "/timeout"}))
           is-pool-timeout-error?
           (fn [req-fut]


### PR DESCRIPTION
This is backward-compatible because it still supports the current `:conn-` -prefixed keys.

Fixes #477.

I don’t know if I was supposed to edit that `core_old.clj` file :man_shrugging: 