### PR TITLE
Add support for proxy scheme

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,8 @@
                                   ;; logging
                                   [org.apache.logging.log4j/log4j-api "2.11.0"]
                                   [org.apache.logging.log4j/log4j-core "2.11.0"]
-                                  [org.apache.logging.log4j/log4j-1.2-api "2.11.0"]]
+                                  [org.apache.logging.log4j/log4j-1.2-api "2.11.0"]
+                                  [org.mock-server/mockserver-netty "5.5.1"]]
                    :plugins [[lein-ancient "0.6.15"]
                              [jonase/eastwood "0.2.5"]
                              [lein-kibit "0.1.5"]

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -559,7 +559,7 @@
             cookie-store cookie-policy headers multipart query-string
             redirect-strategy max-redirects retry-handler
             request-method scheme server-name server-port socket-timeout
-            uri response-interceptor proxy-host proxy-port proxy-scheme
+            uri response-interceptor proxy-host proxy-port
             http-client-context http-request-config http-client
             proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth]
      :as req} respond raise]

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -179,7 +179,8 @@
 (deftest ^:integration makes-get-request-with-proxy
   (run-server)
   (let [resp (request {:request-method :get :uri "/get"
-                       :proxy-host "localhost" :proxy-port "18081" :proxy-scheme "https"})]
+                       :proxy-host "localhost" :proxy-port 18081 :proxy-scheme "http"
+                       :proxy-ignore-hosts #{"fake-host"}})]
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 


### PR DESCRIPTION
Adds support for a proxy-scheme parameter, to allow proxies that use `https`.

Also added a test for proxy using https://github.com/jamesdbloom/mockserver.