### PR TITLE
Remove client-params example

### DIFF
--- a/README.org
+++ b/README.org
@@ -187,12 +187,6 @@ Example requests:
 (client/get "http://example.com"
             {:headers {:foo ["bar" "baz"], :eggplant "quux"}})
 
-;; Set any specific client parameters manually:
-(client/post "http://example.com"
-             {:client-params {"http.protocol.allow-circular-redirects" false
-                              "http.protocol.version" HttpVersion/HTTP_1_0
-                              "http.useragent" "clj-http"}})
-
 ;; Completely ignore cookies:
 (client/post "http://example.com" {:cookie-policy :none})
 ;; There are also multiple ways to handle cookies


### PR DESCRIPTION
3.0.0 seems to have dropped support for this.

User-Agent can now be passed via headers, see https://github.com/cburgmer/buildviz/commit/d6f5c81f666384e8fef0515a6912e68d3783f78a