### PR TITLE
Fixes #482: async mgr "reuseable -> reusable"

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -385,7 +385,7 @@
         [io-reactor nil registry nil nil timeout
          java.util.concurrent.TimeUnit/SECONDS])))
 
-(defn ^PoolingNHttpClientConnectionManager make-reuseable-async-conn-manager
+(defn ^PoolingNHttpClientConnectionManager make-reusable-async-conn-manager
   "Creates a default pooling async connection manager with the specified
   options. Handles the same options as make-reusable-conn-manager plus
   :io-config which should be a map containing some of the following keys:
@@ -428,6 +428,11 @@
     (when default-per-route
       (.setDefaultMaxPerRoute conn-man default-per-route))
     conn-man))
+
+(defn ^PoolingNHttpClientConnectionManager make-reuseable-async-conn-manager
+  "Wraps correctly-spelled version - keeping for backwards compatibility."
+  [opts]
+  (make-reusable-async-conn-manager opts))
 
 (defmulti shutdown-manager
   "Shut down the given connection manager, if it is not nil"

--- a/test/clj_http/test/conn_mgr_test.clj
+++ b/test/clj_http/test/conn_mgr_test.clj
@@ -181,8 +181,10 @@
   (let [regular (conn-mgr/make-regular-conn-manager {})
         regular-reusable (conn-mgr/make-reusable-conn-manager {})
         async (conn-mgr/make-regular-async-conn-manager {})
-        async-reusable (conn-mgr/make-reuseable-async-conn-manager {})]
+        async-reusable (conn-mgr/make-reusable-async-conn-manager {})
+        async-reuseable (conn-mgr/make-reuseable-async-conn-manager {})]
     (is (false? (conn-mgr/reusable? regular)))
     (is (true? (conn-mgr/reusable? regular-reusable)))
     (is (false? (conn-mgr/reusable? async)))
-    (is (true? (conn-mgr/reusable? async-reusable)))))
+    (is (true? (conn-mgr/reusable? async-reusable)))
+    (is (true? (conn-mgr/reusable? async-reuseable)))))


### PR DESCRIPTION
This addresses a naming inconsistency in conn mgr functions.