### PR TITLE
Add :http-client-builder option.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1339,6 +1339,14 @@ Each of these variables is a sequence of functions of two arguments, the http bu
 
 The functions are run in the order they are passed in (inside a =doseq=).
 
+By specifying =:http-client-builder=, your own instance of
+=HttpClientBuilder= will be used. A supplied =HttpClientBuilder= which
+sets the connection manager, redirect strategy, retry handler, route
+planner, cache, or cookie spec registry may find these overridden by
+clj-http's =:connection-manager=, =:redirect-strategy=,
+=:retry-handler=, =:cache=, or =:cookie-policy-registry= or
+=:cookie-spec=, respectively.
+
 * Development
 :PROPERTIES:
 :CUSTOM_ID: h-65bbf017-2e8b-4c43-824b-24b89cc27a70

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -309,15 +309,19 @@
   [{:keys [retry-handler request-interceptor
            response-interceptor proxy-host proxy-port
            http-builder-fns cookie-spec
-           cookie-policy-registry]
+           cookie-policy-registry
+           ^HttpClientBuilder http-client-builder]
     :as req}
    caching?
    conn-mgr
    & [http-url proxy-ignore-hosts]]
   ;; have to let first, otherwise we get a reflection warning on (.build)
   (let [cache? (opt req :cache)
-        builder (-> (if caching?
+        builder (-> (cond
+                      http-client-builder http-client-builder
+                      caching?
                       ^HttpClientBuilder (CachingHttpClientBuilder/create)
+                      :else
                       ^HttpClientBuilder (HttpClients/custom))
                     (.setConnectionManager conn-mgr)
                     (.setRedirectStrategy


### PR DESCRIPTION
This adds an advanced option for specifying the `HttpClientBuilder`.

My motivation was so that I could use https://metrics.dropwizard.io/4.0.0/manual/httpclient.html, e.g.

```clojure
(def builder 
  (InstrumentedHttpClients/custom
   metrics.core/default-registry
   com.codahale.metrics.httpclient.HttpClientMetricNameStrategies/QUERYLESS_URL_AND_METHOD))
(clj-http.client/get
 "https://example.com/"
 {:http-client-builder builder})
```

(maybe that should be added to the readme or as an example?)

Thanks!