### PR TITLE
Throw on missing coercing dependency

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -475,11 +475,10 @@
 
 (defn coerce-json-body
   [request {:keys [body] :as resp} keyword? strict? & [charset]]
+  {:pre [json-enabled?]}
   (let [charset (or charset (response-charset resp))
-        body (if json-enabled?
-               (if (can-parse-body? request resp)
-                 (decode-json-body body keyword? strict? charset)
-                 (util/force-string body charset))
+        body (if (can-parse-body? request resp)
+               (decode-json-body body keyword? strict? charset)
                (util/force-string body charset))]
     (assoc resp :body body)))
 
@@ -496,21 +495,19 @@
 (defn coerce-transit-body
   [{:keys [transit-opts] :as request}
    {:keys [body] :as resp} type & [charset]]
+  {:pre [transit-enabled?]}
   (let [charset (or charset (response-charset resp))
-        body (if transit-enabled?
-               (if (can-parse-body? request resp)
-                 (parse-transit (util/force-stream body) type transit-opts)
-                 (util/force-string body charset))
-               nil)]
+        body (if (can-parse-body? request resp)
+               (parse-transit (util/force-stream body) type transit-opts)
+               (util/force-string body charset))]
     (assoc resp :body body)))
 
 (defn coerce-form-urlencoded-body
   [_request {:keys [body] :as resp}]
+  {:pre [ring-codec-enabled?]}
   (let [charset (response-charset resp)
         body (util/force-string body charset)]
-    (assoc resp :body (if ring-codec-enabled?
-                        (-> body form-decode keywordize-keys)
-                        body))))
+    (assoc resp :body (-> body form-decode keywordize-keys))))
 
 (defmulti coerce-content-type (fn [req resp] (:content-type resp)))
 

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1554,7 +1554,15 @@
            (:body (client/coerce-response-body {:as :auto}
                                                auto-www-form-urlencoded-resp))
            (:body (client/coerce-response-body {:as :x-www-form-urlencoded}
-                                               www-form-urlencoded-resp))))))
+                                               www-form-urlencoded-resp))))
+
+    (testing "throws AssertionError when optional libraries are not loaded"
+      (with-redefs [client/json-enabled? false]
+        (is (thrown? AssertionError (client/coerce-response-body {:as :json} json-resp)))
+        (is (thrown? AssertionError (client/coerce-response-body {:as :auto} json-resp))))
+      (with-redefs [client/transit-enabled? false]
+        (is (thrown? AssertionError (client/coerce-response-body {:as :transit+json} transit-json-resp)))
+        (is (thrown? AssertionError (client/coerce-response-body {:as :transit+msgpack} transit-msgpack-resp)))))))
 
 (deftest t-reader-coercion
   (let [read-lines (fn [reader] (vec (take-while not-empty (repeatedly #(.readLine reader)))))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1562,7 +1562,10 @@
         (is (thrown? AssertionError (client/coerce-response-body {:as :auto} json-resp))))
       (with-redefs [client/transit-enabled? false]
         (is (thrown? AssertionError (client/coerce-response-body {:as :transit+json} transit-json-resp)))
-        (is (thrown? AssertionError (client/coerce-response-body {:as :transit+msgpack} transit-msgpack-resp)))))))
+        (is (thrown? AssertionError (client/coerce-response-body {:as :transit+msgpack} transit-msgpack-resp))))
+      (with-redefs [client/ring-codec-enabled? false]
+        (is (thrown? AssertionError (client/coerce-response-body {:as :x-www-form-urlencoded} www-form-urlencoded-resp)))
+        (is (thrown? AssertionError (client/coerce-response-body {:as :auto} auto-www-form-urlencoded-resp)))))))
 
 (deftest t-reader-coercion
   (let [read-lines (fn [reader] (vec (take-while not-empty (repeatedly #(.readLine reader)))))


### PR DESCRIPTION
This ensures coercing functions that depend on optional dependencies fail if that dependency is missing, instead of silently failing.

Fixes https://github.com/dakrone/clj-http/issues/479.

However, I’m not sure how to add a test for this:
I tried to created Leiningen profiles to isolate dependencies and so create a profile without Cheshire but other tests fail in that profile because both `core_test.clj` and `client_test.clj` require it.
I then tried to move integration tests in separate namespaces tagged `:integration` but unfortunately there’s still _one_ non-`^:integration` test in `client_test.clj` that relies on Cheshire.

Any idea?