### PR TITLE
Allow for specifying the preferred auth schemes in http requests.

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -186,7 +186,8 @@
                               cookie-spec
                               ; deprecated
                               conn-request-timeout
-                              conn-timeout]
+                              conn-timeout
+                              auth-schemes]
                        :as req}]
   (let [config (-> (RequestConfig/custom)
                    (.setConnectTimeout (or connection-timeout conn-timeout -1))
@@ -198,7 +199,8 @@
                     (boolean (opt req :allow-circular-redirects)))
                    (.setRelativeRedirectsAllowed
                     ((complement false?)
-                     (opt req :allow-relative-redirects))))]
+                     (opt req :allow-relative-redirects)))
+                   (.setTargetPreferredAuthSchemes auth-schemes))]
     (if cookie-spec
       (.setCookieSpec config CUSTOM_COOKIE_POLICY)
       (.setCookieSpec config (get-cookie-policy req)))


### PR DESCRIPTION
In my specific case that patch allowed me to work around an annoying warning at each and every http request that crowded the log file:

    [2019-06-05T12:40:01,590][WARN ][o.a.h.i.a.HttpAuthenticator] NEGOTIATE authentication error: Invalid name provided (Mechanism level: KrbException: Cannot locate default realm)

The server accepts NEGOTIATE and NTLM but NEGOTIATE fails.

The patch lets me do requests like this:

    (get "http://whatever-ms-server.com/some/page.aspx"
         {:ntlm-auth ["user" "password"]
          :auth-schemes ["NTLM"]})

The :auth-schemes parameter avoids the NEGOTIATE attempt.
