### PR TITLE
When using :as :json, force parsing to finish before closing connection.

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -141,7 +141,7 @@
   "Resolve and apply cheshire's json stream decoding dynamically."
   [& args]
   {:pre [json-enabled?]}
-  (apply (ns-resolve (symbol "cheshire.core") (symbol "decode-stream")) args))
+  (doall (apply (ns-resolve (symbol "cheshire.core") (symbol "decode-stream")) args)))
 
 (defn ^:dynamic form-decode
   "Resolve and apply ring-codec's form decoding dynamically."

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1556,6 +1556,15 @@
            (:body (client/coerce-response-body {:as :x-www-form-urlencoded}
                                                www-form-urlencoded-resp))))))
 
+(deftest t-as-json-is-not-lazy
+  (let [json-body (ByteArrayInputStream. (.getBytes "[1, {\"foo\":\"bar\"}]"))
+        json-resp {:body json-body :status 200
+                   :headers {"content-type" "application/json"}}
+        expected '(1 {:foo "bar"})
+        body (:body (client/coerce-response-body {:as :json} json-resp))]
+    (is (= true (realized? body)))
+    (is (= expected body))))
+
 (deftest ^:integration t-with-middleware
   (run-server)
   (is (:request-time (request {:uri "/get" :method :get})))


### PR DESCRIPTION
Some JSON response (array at top level) get parsed lazily.
This parsing might not be finished when the underlying stream gets closed
causing parsing to fail with IOException "Stream closed".

This PR calls `doall` on the parsing result before the connection is closed.

Fixes #489.