### PR TITLE
#309 Adjust :uri to comply with RFC2396

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -174,8 +174,8 @@
                      util/url-encode))))
 
 (defn get-url-encoded-uri
-  [^java.net.URL url]
-  (-> url .toURI str url-encode-illegal-characters))
+  [^String url]
+  (-> url url-encode-illegal-characters URL. .toURI str))
 
 (defn get-url-encoded-path
   [^java.net.URL url]
@@ -189,7 +189,7 @@
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
      :url url
-     :uri (get-url-encoded-uri url-parsed)
+     :uri (get-url-encoded-uri url)
      :path (get-url-encoded-path url-parsed)
      :user-info (if-let [user-info (.getUserInfo url-parsed)]
                   (util/url-decode user-info))

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -10,7 +10,7 @@
             [clojure.string :as str]
             [clojure.walk :refer [keywordize-keys prewalk]])
   (:import (java.io InputStream File ByteArrayOutputStream ByteArrayInputStream)
-           (java.net URL UnknownHostException)
+           (java.net URI URL UnknownHostException)
            (java.nio.charset StandardCharsets)
            (org.apache.hc.core5.http ContentType)
            (org.apache.hc.core5.http.io.entity BufferedHttpEntity ByteArrayEntity
@@ -175,7 +175,7 @@
 
 (defn get-url-encoded-uri
   [^String url]
-  (-> url url-encode-illegal-characters URL. .toURI str))
+  (-> url url-encode-illegal-characters URI. str))
 
 (defn get-url-encoded-path
   [^java.net.URL url]

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -173,6 +173,14 @@
         (str/replace #"[^a-zA-Z0-9\.\-\_\~\!\$\&\'\(\)\*\+\,\;\=\:\@\/\%\?]"
                      util/url-encode))))
 
+(defn get-url-encoded-uri
+  [^java.net.URL url]
+  (-> url .toURI str url-encode-illegal-characters))
+
+(defn get-url-encoded-path
+  [^java.net.URL url]
+  (-> url .getPath url-encode-illegal-characters))
+
 (defn parse-url
   "Parse a URL string into a map of interesting parts."
   [url]
@@ -181,7 +189,8 @@
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
      :url url
-     :uri (url-encode-illegal-characters (.getPath url-parsed))
+     :uri (get-url-encoded-uri url-parsed)
+     :path (get-url-encoded-path url-parsed)
      :user-info (if-let [user-info (.getUserInfo url-parsed)]
                   (util/url-decode user-info))
      :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
@@ -190,14 +199,14 @@
   "Takes a map of url-parts and generates a string representation.
   WARNING: does not do any sort of encoding! Don't use this for strict RFC
   following!"
-  [{:keys [scheme server-name server-port uri user-info query-string]}]
+  [{:keys [scheme server-name server-port uri path user-info query-string]}]
   (str (name scheme) "://"
        (if (seq user-info)
          (str user-info "@" server-name)
          server-name)
        (when server-port
          (str ":" server-port))
-       uri
+       path
        (when (seq query-string)
          (str "?" query-string))))
 

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -641,7 +641,7 @@
     (is (= :http (:scheme resp)))
     (is (= "google.com" (:server-name resp)))
     (is (= 8080 (:server-port resp)))
-    (is (= "/baz%20foo" (:uri resp)))
+    (is (= "/baz%20foo" (:path resp)))
     (is (= "bar=bat%20bit?" (:query-string resp)))))
 
 (deftest apply-on-url
@@ -653,7 +653,7 @@
     (is (= :http (:scheme @resp)))
     (is (= "google.com" (:server-name @resp)))
     (is (= 8080 (:server-port @resp)))
-    (is (= "/baz%20foo" (:uri @resp)))
+    (is (= "/baz%20foo" (:path @resp)))
     (is (= "bar=bat%20bit?" (:query-string @resp)))
     (is (not (realized? exception)))))
 
@@ -1144,11 +1144,11 @@
 (deftest test-url-encode-path
   (is (= (client/url-encode-illegal-characters "?foo bar+baz[]75")
          "?foo%20bar+baz%5B%5D75"))
-  (is (= {:uri (str "/:@-._~!$&'()*+,="
-                    ";"
-                    ":@-._~!$&'()*+,"
-                    "="
-                    ":@-._~!$&'()*+,==")
+  (is (= {:path (str "/:@-._~!$&'()*+,="
+                     ";"
+                     ":@-._~!$&'()*+,"
+                     "="
+                     ":@-._~!$&'()*+,==")
           :query-string (str "/?:@-._~!$'()*+,;"
                              "="
                              "/?:@-._~!$'()*+,;==")}
@@ -1157,7 +1157,7 @@
                        (str "http://example.com/:@-._~!$&'()*+,=;:@-._~!$&'()*+"
                             ",=:@-._~!$&'()*+,==?/?:@-._~!$'()*+,;=/?:@-._~!$'("
                             ")*+,;==#/?:@-._~!$&'()*+,;="))
-                      [:uri :query-string])))
+                      [:path :query-string])))
   (let [all-chars (apply str (map char (range 256)))
         all-legal (client/url-encode-illegal-characters all-chars)]
     (is (= all-legal


### PR DESCRIPTION
Fixes #309 

`:uri` is now the url-encoded full url as discussed in the issue.

It is being run through the java.net.URI constructor after being url-encoded since the URI class implements the spec.

`:path` has been added to replace the previous usage of :uri for consumers of existing functionality.

Existing tests have been adjusted.

This is a breaking change fit for 4.x as it changes the meaning of `:uri` for existing consumers.