### PR TITLE
Switch oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     # 'master' is the new apache 5 client, and not passing yet
     # - master
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11


### PR DESCRIPTION
TravisCI appears to be rolling out `xenial` build vms by default now. It no longer has oraclejdk8 packaged, however it does have openjdk8. See https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support