### PR TITLE
add multipart-mode request option

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -563,6 +563,7 @@
             uri response-interceptor proxy-host proxy-port
             http-client-context http-request-config http-client
             proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth
+            multipart-mode
             ; deprecated
             conn-timeout conn-request-timeout]
      :as req} respond raise]

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -128,10 +128,12 @@
 (defn create-multipart-entity
   "Takes a multipart vector of maps and creates a MultipartEntity with each
   map added as a part, depending on the type of content."
-  [multipart {:keys [mime-subtype]}]
+  [multipart {:keys [mime-subtype multipart-mode]
+              :or {mime-subtype "form-data"
+                   multipart-mode HttpMultipartMode/STRICT}}]
   (let [mp-entity (doto (MultipartEntityBuilder/create)
-                    (.setStrictMode)
-                    (.setMimeSubtype (or mime-subtype "form-data")))]
+                    (.setMode multipart-mode)
+                    (.setMimeSubtype mime-subtype))]
     (doseq [m multipart]
       (let [name (or (:part-name m) (:name m))
             part (make-multipart-body m)]


### PR DESCRIPTION
HttpMultipartMode supports several multipart modes (see org.apache.http.entity.mime),
yet clj-http uses only STRICT mode.
This pulls request allows to optionally select HttpMultipartMode (e.g. HttpMultipartMode/RFC6532 is required for Mailgun)