### PR TITLE
Add :async-future as an option for async request processing

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,6 +29,7 @@
   - [[#post][POST]]
   - [[#delete][DELETE]]
   - [[#async-http-request][Async HTTP Request]]
+    - [[#async-futures][Async Futures]]
     - [[#cancelling-requests][Cancelling Requests]]
   - [[#coercions][Coercions]]
     - [[#input-coercion][Input coercion]]
@@ -429,12 +430,22 @@ start an async request is easy, for example:
 
 All exceptions thrown during the request will be passed to the raise callback.
 
+*** Async Futures
+Alternatively, if you prefer working with Futures, you can get the async response in the shape of a Future:
+
+#+begin_src clojure
+(def fut (client/get "http://example.com" {:async-future? true}))
+@fut
+#+end_src
+
+Deref-ing the future will return the response map or throw a [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutionException.html][ExecutionException]] on error.
+
 *** Cancelling Requests
 :PROPERTIES:
 :CUSTOM_ID: cancelling-requests
 :END:
 
-Calls to the http methods with =:async true= return an Apache [[https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/concurrent/BasicFuture.html][BasicFuture]] that you can call =.get=
+Calls to the http methods with =:async true or :async-future true= return an Apache [[https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/concurrent/BasicFuture.html][BasicFuture]] that you can call =.get=
 or =.cancel= on. See the Javadocs for =BasicFuture= [[https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/concurrent/BasicFuture.html][here]]. For instance:
 
 #+BEGIN_SRC clojure

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -1169,7 +1169,7 @@
 
 (defn- request*
   [req & [respond raise]]
-  {:pre [(not (and (:async req) (:async-future req)))]}
+  {:pre [(not (and (opt req :async) (opt req :async-future)))]}
   (cond
     (opt req :async)
     (if (some nil? [respond raise])
@@ -1180,7 +1180,7 @@
     (opt req :async-future)
     (let [basic-future (org.apache.http.concurrent.BasicFuture. nil)]
       (request (-> req
-                   (dissoc :async-future)
+                   (dissoc :async :async? :async-future :async-future?)
                    (assoc :async true
                           :oncancel #(.cancel basic-future)))
                #(.completed basic-future %)

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -25,9 +25,9 @@
 
 (defn request
   ([req]
-   (client/request (merge base-req req)))
+   (#'client/request* (merge base-req req)))
   ([req respond raise]
-   (client/request (merge base-req req) respond raise)))
+   (#'client/request* (merge base-req req) respond raise)))
 
 (defn parse-form-params [s]
   (->> (str/split (form-decode-str s) #"&")
@@ -90,6 +90,14 @@
     (is (= "get" (:body @resp)))
     (is (not (realized? exception))))
 
+  ;; roundrtrip with error handling
+  (let [resp (promise)
+        exception (promise)
+        _ (request {:uri "/error" :method :get
+                    :scheme "http"
+                    :async? true} resp exception)]
+    (is (instance? Exception @exception)))
+
   (let [params {:a "1" :b "2"}]
     (doseq [[content-type read-fn]
             [[nil (comp parse-form-params slurp)]
@@ -110,6 +118,45 @@
         (is (= "close" (get-in @resp [:headers "connection"])))
         (is (= params (read-fn (:body @resp))))
         (is (not (realized? exception)))))))
+
+(deftest ^:integration roundtrip-async-future
+  (run-server)
+  ;; roundtrip with scheme as a keyword
+  (let [resp (request {:uri "/get" :method :get
+                       :async-future? true})]
+    (is (= 200 (:status @resp)))
+    (is (= "close" (get-in @resp [:headers "connection"])))
+    (is (= "get" (:body @resp))))
+  ;; roundtrip with scheme as a string
+  (let [resp (request {:uri "/get" :method :get
+                       :scheme "http"
+                       :async-future? true})]
+    (is (= 200 (:status @resp)))
+    (is (= "close" (get-in @resp [:headers "connection"])))
+    (is (= "get" (:body @resp))))
+  ;; error handling
+  (let [resp (request {:uri "/error" :method :get
+                       :async-future? true})]
+    (is (thrown? java.util.concurrent.ExecutionException
+          @resp)))
+
+  (let [params {:a "1" :b "2"}]
+    (doseq [[content-type read-fn]
+            [[nil (comp parse-form-params slurp)]
+             [:x-www-form-urlencoded (comp parse-form-params slurp)]
+             [:edn (comp read-string slurp)]
+             [:transit+json #(client/parse-transit % :json)]
+             [:transit+msgpack #(client/parse-transit % :msgpack)]]]
+      (let [resp (request {:uri "/post"
+                           :as :stream
+                           :method :post
+                           :content-type content-type
+                           :flatten-nested-keys []
+                           :form-params params
+                           :async-future? true})]
+        (is (= 200 (:status @resp)))
+        (is (= "close" (get-in @resp [:headers "connection"])))
+        (is (= params (read-fn (:body @resp))))))))
 
 (def ^:dynamic *test-dynamic-var* nil)
 


### PR DESCRIPTION
Solves #512.

Notes for Reviwer:
I chose to add a separate option `:async-future` instead of changing the existing `:async` implementation to avoid breaking API changes.