### PR TITLE
Update httpcomponents to latest versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,11 +7,11 @@
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.0.0"
   :exclusions [org.clojure/clojure]
-  :dependencies [[org.apache.httpcomponents/httpcore "4.4.11"]
-                 [org.apache.httpcomponents/httpclient "4.5.8"]
-                 [org.apache.httpcomponents/httpclient-cache "4.5.8"]
+  :dependencies [[org.apache.httpcomponents/httpcore "4.4.12"]
+                 [org.apache.httpcomponents/httpclient "4.5.10"]
+                 [org.apache.httpcomponents/httpclient-cache "4.5.10"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.4"]
-                 [org.apache.httpcomponents/httpmime "4.5.8"]
+                 [org.apache.httpcomponents/httpmime "4.5.10"]
                  [commons-codec "1.12"]
                  [commons-io "2.6"]
                  [slingshot "0.12.2"]


### PR DESCRIPTION
This PR will remove warnings mentioned in #514.

List of update deps:
- `org.apache.httpcomponents/httpcore 4.4.12`
- `org.apache.httpcomponents/httpclient 4.5.10`
- `org.apache.httpcomponents/httpclient-cache 4.5.10`
- `org.apache.httpcomponents/httpmime 4.5.10`

Fixes  #514.