### PR TITLE
Set .disableContentCompression in build-http-client

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -323,6 +323,11 @@
                     (.setRedirectStrategy
                      (get-redirect-strategy req))
                     (add-retry-handler retry-handler)
+
+                    ;; prefer using clj-http.client/wrap-decompression
+                    ;; for consistency between sync/async client options
+                    (.disableContentCompression)
+
                     ;; By default, get the proxy settings
                     ;; from the jvm or system properties
                     (.setRoutePlanner


### PR DESCRIPTION
The HttpAsyncClientBuilder does not have this option, which leads to inconsistency of which options to set and runtime behaviour. By disabling it in the HttpClientBuilder and relying on wrap-decompression, the experience for end-users is consistent.

Fixes #510 