### PR TITLE
Add option to add multipart charset

### DIFF
--- a/README.org
+++ b/README.org
@@ -383,6 +383,15 @@ content encodings.
                                    :retry-handler (fn [ex try-count http-context]
                                                     (println "Got:" ex)
                                                     (if (> try-count 4) false true))})
+
+;; to handle a file with non-ascii filename, try :multipart-charset "UTF-8" and :multipart-mode BROWSER_COMPATIBLE
+;; see also: https://stackoverflow.com/questions/3393445/international-characters-in-filename-in-mutipart-formdata
+(import (org.apache.http.entity.mime HttpMultipartMode))
+
+(client/post "http://example.org" {:multipart [{:content (clojure.java.io/file "日本語.txt")}]
+                                   :multipart-mode HttpMultipartMode/BROWSER_COMPATIBLE
+                                   :multipart-charset "UTF-8"} )
+
 #+END_SRC
 
 A word about flattening nested =:query-params= and =:form-params= maps. There are essentially three

--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -568,7 +568,7 @@
             uri response-interceptor proxy-host proxy-port
             http-client-context http-request-config http-client
             proxy-ignore-hosts proxy-user proxy-pass digest-auth ntlm-auth
-            multipart-mode
+            multipart-mode multipart-charset
             ; deprecated
             conn-timeout conn-request-timeout]
      :as req} respond raise]

--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -128,12 +128,14 @@
 (defn create-multipart-entity
   "Takes a multipart vector of maps and creates a MultipartEntity with each
   map added as a part, depending on the type of content."
-  [multipart {:keys [mime-subtype multipart-mode]
+  [multipart {:keys [mime-subtype multipart-mode multipart-charset]
               :or {mime-subtype "form-data"
                    multipart-mode HttpMultipartMode/STRICT}}]
   (let [mp-entity (doto (MultipartEntityBuilder/create)
                     (.setMode multipart-mode)
                     (.setMimeSubtype mime-subtype))]
+    (when multipart-charset
+      (.setCharset mp-entity (encoding-to-charset multipart-charset)))
     (doseq [m multipart]
       (let [name (or (:part-name m) (:name m))
             part (make-multipart-body m)]

--- a/test/clj_http/test/multipart_test.clj
+++ b/test/clj_http/test/multipart_test.clj
@@ -176,6 +176,9 @@
         (is (= "testname" (.getFilename body)))))))
 
 (deftest test-multipart-content-charset
-  (testing "charset is nil for all multipart requests"
+  (testing "charset is nil if no multipart-charset is supplied"
     (let [mp-entity (create-multipart-entity [] nil)]
-      (is (nil? (EntityUtils/getContentCharSet mp-entity))))))
+      (is (nil? (EntityUtils/getContentCharSet mp-entity)))))
+  (testing "charset is set if a multipart-charset is supplied"
+    (let [mp-entity (create-multipart-entity [] {:multipart-charset "UTF-8"})]
+      (is (= "UTF-8" (EntityUtils/getContentCharSet mp-entity))))))


### PR DESCRIPTION
related issue: https://github.com/dakrone/clj-http/issues/472

To handle non-ascii characters in a multipart filename, we need a way to set .setCharset and .setMode BROWSER_COMPATIBLE.

see also:
https://stackoverflow.com/questions/3393445/international-characters-in-filename-in-mutipart-formdata
https://qiita.com/otomoringo/items/f523c5ece1ef8471d149#修正箇所

I'm not sure if `.setMode STRICT` and `.setCharset` is used together. I didn't add validation for now.