### PR TITLE
Add support for async callbacks with `client/request`

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,7 +72,6 @@
 - [[#other-libraries-providing-middleware][Other Libraries Providing Middleware]]
 - [[#license][License]]
 
-
 * Branches
 :PROPERTIES:
 :CUSTOM_ID: h-e390585c-cbd8-4e94-b36b-4e9c27c16720
@@ -428,12 +427,19 @@ start an async request is easy, for example:
 
 #+BEGIN_SRC clojure
 ;; :async? in options map need to be true
-(client/get "http://example.com"
-            {:async? true}
-            ;; respond callback
-            (fn [response] (println "response is:" response))
-            ;; raise callback
-            (fn [exception] (println "exception message is: " (.getMessage exception))))
+  (client/get "http://example.com"
+              {:async true }
+              ;; respond callback
+              (fn [response] (println "response is:" response))
+              ;; raise callback
+              (fn [exception] (println "exception message is: " (.getMessage exception))))
+
+  ;; equivalent using request
+  (client/request {:method :get
+                   :url "http://example.com"
+                   :async true
+                   :respond (fn [response] (println "response is:" response))
+                   :raise (fn [exception] println "exception message is: " (.getMessage exception))})
 #+END_SRC
 
 All exceptions thrown during the request will be passed to the raise callback.

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -1124,6 +1124,25 @@
   Automatically bound when `with-middleware` is used."
   default-middleware)
 
+(defn- async-transform
+  [client]
+  (fn
+    ([req]
+     (cond
+       (opt req :async)
+       (let [{:keys [respond raise]} req]
+         (when (some nil? [respond raise])
+           (throw (IllegalArgumentException. "If :async? is true, you must pass respond and raise")))
+         (client req respond raise))
+
+       :else
+       (client req)))
+
+    ;; In versions of clj-http older than 3.11, the 3-arity invocation implied the
+    ;; request should be handled as async
+    ([req respond raise]
+     (client (assoc req :async true) respond raise))))
+
 (defn wrap-request
   "Returns a batteries-included HTTP request function corresponding to the given
   core client. See default-middleware for the middleware wrappers that are used
@@ -1131,7 +1150,8 @@
   ([request]
    (wrap-request request default-middleware))
   ([request middleware]
-   (reduce #(%2 %1) request middleware)))
+   (async-transform
+    (reduce #(%2 %1) request middleware))))
 
 (def ^:dynamic request
   "Executes the HTTP request corresponding to the given map and returns
@@ -1166,68 +1186,35 @@
   `(when (nil? ~url)
      (throw (IllegalArgumentException. "Host URL cannot be nil"))))
 
-(defn- request*
-  [req [respond raise]]
-  (if (opt req :async)
-    (if (some nil? [respond raise])
-      (throw (IllegalArgumentException.
-              "If :async? is true, you must pass respond and raise"))
-      (request (dissoc req :respond :raise) respond raise))
-    (request req)))
+(defn- request-method
+  ([method url]
+   (check-url! url)
+   (request {:method method :url url}))
+  ([method url req]
+   (check-url! url)
+   (request (merge req {:method method :url url})))
+  ([method url req respond raise]
+   (check-url! url)
+   (request (merge req {:method method :url url :async true :respond respond :raise raise}))))
 
-(defn get
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :get :url url}) r))
+(defmacro ^:private def-http-method [method]
+  `(do
+     (def ~method (partial request-method ~(keyword method)))
+     (alter-meta! (resolve '~method) assoc
+                  :doc ~(str "Like #'request, but sets the :method and :url as appropriate.")
+                  :arglists '([~(symbol "url")]
+                              [~(symbol "url") ~(symbol "req")]
+                              [~(symbol "url") ~(symbol "req") ~(symbol "respond") ~(symbol "raise")]))))
 
-(defn head
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :head :url url}) r))
-
-(defn post
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :post :url url}) r))
-
-(defn put
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :put :url url}) r))
-
-(defn delete
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :delete :url url}) r))
-
-(defn options
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :options :url url}) r))
-
-(defn copy
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :copy :url url}) r))
-
-(defn move
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :move :url url}) r))
-
-(defn patch
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req & r]]
-  (check-url! url)
-  (request* (merge req {:method :patch :url url}) r))
+(def-http-method get)
+(def-http-method head)
+(def-http-method post)
+(def-http-method put)
+(def-http-method delete)
+(def-http-method options)
+(def-http-method copy)
+(def-http-method move)
+(def-http-method patch)
 
 (defmacro with-middleware
   "Perform the body of the macro with a custom middleware list.

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -1128,11 +1128,10 @@
   "Returns a batteries-included HTTP request function corresponding to the given
   core client. See default-middleware for the middleware wrappers that are used
   by default"
-  [request]
-  (reduce (fn wrap-request* [request middleware]
-            (middleware request))
-          request
-          default-middleware))
+  ([request]
+   (wrap-request request default-middleware))
+  ([request middleware]
+   (reduce #(%2 %1) request middleware)))
 
 (def ^:dynamic request
   "Executes the HTTP request corresponding to the given map and returns
@@ -1241,9 +1240,7 @@
   [middleware & body]
   `(let [m# ~middleware]
      (binding [*current-middleware* m#
-               clj-http.client/request (reduce #(%2 %1)
-                                               clj-http.core/request
-                                               m#)]
+               clj-http.client/request (wrap-request clj-http.core/request m#)]
        ~@body)))
 
 (defmacro with-additional-middleware


### PR DESCRIPTION
This change normalizes the handling of async requests by pushing the complexity of `request*` into `wrap-request`.

This also solves #520.
