### PR TITLE
Added the ability to use a custom DNS resolver

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,15 @@
+name: Clojure CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: lein deps
+    - name: Run tests
+      run: lein test :all

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -57,7 +57,7 @@
   (SSLIOSessionStrategy/getDefaultStrategy))
 
 (defn- dns-custom-resolver
-  "Given a map with a string hostname key and a byte array ip address vector [10 10 22 1] {"foobar.com" [127 0 0 1] ...}
+  "Given a map with a string hostname key and a byte array ip address vector [10 10 22 1] {\"foobar.com\" [127 0 0 1] ...}
    and when the :custom-dns-resolver is added to the options use the function to override normal DNS resolution. Useful when
    testing when you dont have write permissions to a /etc/hosts file and you need to use TLS with SNI (server name indication).
    Uses the system resolver if the :server-name is not found in the supplied map."
@@ -65,7 +65,6 @@
   (reify
     DnsResolver
     (^"[Ljava.net.InetAddress;" resolve [this ^String host]
-     (println "hostmap:" host-map "host:" host)
      (if (contains? host-map host)
        (into-array [(InetAddress/getByAddress host (byte-array (get host-map host)))])
        (.resolve (SystemDefaultDnsResolver.) host)))))

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -44,7 +44,10 @@
   (when b
     (cond
       (instance? InputStream b)
-      (GZIPInputStream. b)
+      (try 
+        (GZIPInputStream. b)
+        (catch java.io.EOFException e
+          nil))
       :else
       (IOUtils/toByteArray (GZIPInputStream. (ByteArrayInputStream. b))))))
 

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -177,6 +177,14 @@
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 
+(deftest ^:integration custom-dns-resolver-ipv6
+  (run-server)
+  (let [resp (request {:request-method :get :uri "/get"
+                       :server-name "foo.bar.com"
+                       :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 1]}})]
+    (is (= 200 (:status resp)))
+    (is (= "get" (slurp-body resp)))))
+
 (deftest ^:integration save-request-option
   (run-server)
   (let [resp (request {:request-method :post

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -169,6 +169,14 @@
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 
+(deftest ^:integration custom-dns-resolver
+  (run-server)
+  (let [resp (request {:request-method :get :uri "/get"
+                       :server-name "foo.bar.com"
+                       :custom-dns-resolver {"foo.bar.com" [127 0 0 1]}})]
+    (is (= 200 (:status resp)))
+    (is (= "get" (slurp-body resp)))))
+
 (deftest ^:integration save-request-option
   (run-server)
   (let [resp (request {:request-method :post

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -180,7 +180,7 @@
 (deftest ^:integration custom-dns-resolver-ipv6
   (run-server)
   (let [resp (request {:request-method :get :uri "/get"
-                       :server-name "foo.bar.com"
+                       :server-name "foo.bar.ipv6"
                        :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 1]}})]
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -188,13 +188,13 @@
        (count)))
 
 (deftest ^:integration custom-dns-resolver-ipv6
-  (if (<= 0 (ipv6-interfaces))
+  (if (<= (ipv6-interfaces) 0)
     (println "IPv6 not enabled, skipping custom-dns-resolver-ipv6 test.")
     (do
       (run-server)
       (let [resp (request {:request-method :get :uri "/get"
                            :server-name "foo.bar.ipv6"
-                           :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 1]}})]
+                           :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]}})]
         (is (= 200 (:status resp)))
         (is (= "get" (slurp-body resp)))))))
 

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -9,7 +9,7 @@
             [clojure.test :refer :all]
             [ring.adapter.jetty :as ring])
   (:import (java.io ByteArrayInputStream)
-           (java.net SocketTimeoutException)
+           (java.net NetworkInterface SocketTimeoutException)
            (java.util.concurrent TimeoutException TimeUnit)
            (org.apache.http.params CoreConnectionPNames CoreProtocolPNames)
            (org.apache.http.message BasicHeader BasicHeaderIterator)
@@ -177,13 +177,26 @@
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 
+(defn ipv6-interfaces
+  "Return # of IPv6 interfaces"
+  []
+  (->> (enumeration-seq (NetworkInterface/getNetworkInterfaces))
+       (map #(.getInterfaceAddresses %))
+       (apply concat)
+       (map #(.getAddress %))
+       (filter #(instance? java.net.Inet6Address %))
+       (count)))
+
 (deftest ^:integration custom-dns-resolver-ipv6
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get"
-                       :server-name "foo.bar.ipv6"
-                       :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 1]}})]
-    (is (= 200 (:status resp)))
-    (is (= "get" (slurp-body resp)))))
+  (if (<= 0 (ipv6-interfaces))
+    (println "IPv6 not enabled, skipping custom-dns-resolver-ipv6 test.")
+    (do
+      (run-server)
+      (let [resp (request {:request-method :get :uri "/get"
+                           :server-name "foo.bar.ipv6"
+                           :custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 1]}})]
+        (is (= 200 (:status resp)))
+        (is (= "get" (slurp-body resp)))))))
 
 (deftest ^:integration save-request-option
   (run-server)


### PR DESCRIPTION
In the case that you are working on a server where you do not have privileges to edit the /etc/hosts file, it is useful to be able to use the custom dns resolver option supported by the apache client. It is similar to the --resolve <host:port:address[,address]...> of cUrl. It is also the only way to test virtual hosts like an OpenShift cluster where encrypted traffic is passed through proxy to the intended backend using the TLS SNI extension to determine where to route the request.
To this end I added a config to the client of 

:custom-dns-resolver {"foo.bar.com" [127 0 0 1]} which maps foo.bar.com to 127.0.0.1.

I only changed the BasicHttpClientConnectionManager and added an ipv4 test, and ipv6 test and a function ipv6-interfaces to test if IPV6 was available before running the ipv6 test. The function should probably be in the utils file, not the core_test.clj file.

I also added a github action (that's the workflow file) to run the tests :all on checkin. It seems to work just fine, except the null gzip test threw an EOFException. I wrapped it in a try catch block. I do not know why this was not happening previously. It throws the exception locally and in the github action.

Please let me know if this is good enough or if you would need anything else done before accepting my merge request.