### PR TITLE
Fix #528: resolve performance warnings

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -466,7 +466,7 @@
     (let [^BufferedReader br (io/reader (util/force-stream body))]
       (try
         (.mark br 1)
-        (let [^int first-char (try (.read br) (catch EOFException _ -1))]
+        (let [first-char (int (try (.read br) (catch EOFException _ -1)))]
           (case first-char
             -1 nil
             (do (.reset br)

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -71,7 +71,7 @@
   (if (instance? InputStream b)
     (let [^PushbackInputStream bs (PushbackInputStream. b)]
       (try
-        (let [^int first-byte (try (.read bs) (catch EOFException _ -1))]
+        (let [first-byte (int (try (.read bs) (catch EOFException _ -1)))]
           (case first-byte
             -1 (byte-array 0)
             (do (.unread bs first-byte)
@@ -85,7 +85,7 @@
   (if (instance? InputStream s)
     (let [^PushbackInputStream bs (PushbackInputStream. s)]
       (try
-        (let [^int first-byte (try (.read bs) (catch EOFException _ -1))]
+        (let [first-byte (int (try (.read bs) (catch EOFException _ -1)))]
           (case first-byte
             -1 ""
             (do (.unread bs first-byte)


### PR DESCRIPTION
This should resolve all reflection warnings in the `src` folder.