### PR TITLE
Add ability to override the use of the OS DNS Resolver.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1437,6 +1437,48 @@ things:
 In previous versions of =clj-http= (<= 3.10.0), =clj-http= defaulted to lazily parsing JSON, but this
 was slow and also confused users who didn't expect laziness.
 
+** DNS Resolution
+
+Users may add their own DNS resolver function to override the OS provided DNS resolver. This is useful in situations where you are unable to change the name to IP Address mapping. It is analogus to the --reslove flag present in cUrl. This example uses the org.apache.http.impl.conn.InMemoryDnsResolver to allow resolution of example.com to IP Address 127.0.0.1. 
+
+#+BEGIN_SRC clojure
+(client/get "https://example.com" {:keystore "/path/to/keystore.ks"
+                                   :keystore-type "jks" ; default: jks
+                                   :keystore-pass "secretpass"
+                                   :trust-store "/path/to/trust-store.ks"
+                                   :trust-store-type "jks" ; default jks
+                                   :trust-store-pass "trustpass"
+                                   :dns-resolver (doto (InMemoryDnsResolver.)
+                                                   (.add "example.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})
+#+END_SRC
+
+This option is supported for all of the connection managers. You are free to implement any DnsResolver function you like. Here is a more Clojuresq example of a DnsResolver that attempts to look up the hostname in the supplied map and if it is not found passes it on to the system DNS resolver. Note how IPV6 addresses are specified.
+
+#+BEGIN_SRC clojure
+(defn custom-dns-resolver
+  "Given a map with a string hostname key and a byte array ip address vector [10 10 22 1] {\"foobar.com\" [127 0 0 1] ...}
+   and when the :custom-dns-resolver is added to the options use the function to override normal DNS resolution. Useful when
+   testing when you dont have write permissions to a /etc/hosts file and you need to use TLS with SNI (server name indication).
+   Uses the system resolver if the :server-name is not found in the supplied map."
+  [host-map]
+  (reify
+    DnsResolver
+    (^"[Ljava.net.InetAddress;" resolve [this ^String host]
+     (if (contains? host-map host)
+       (into-array [(InetAddress/getByAddress host (byte-array (get host-map host)))])
+       (.resolve (SystemDefaultDnsResolver.) host)))))Editing clj-http_README.org at 3.x · fhitchen_clj-http
+       
+(client/get "https://example.com" {:keystore "/path/to/keystore.ks"
+                                   :keystore-type "jks" ; default: jks
+                                   :keystore-pass "secretpass"
+                                   :trust-store "/path/to/trust-store.ks"
+                                   :trust-store-type "jks" ; default jks
+                                   :trust-store-pass "trustpass"
+                                   :dns-resolver (custom-dns-resolver {"example.com" [127 0 0 1]
+                                                                       "www.google.com" [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]})})
+#+END_SRC
+       
+
 * Development
 :PROPERTIES:
 :CUSTOM_ID: h-65bbf017-2e8b-4c43-824b-24b89cc27a70

--- a/README.org
+++ b/README.org
@@ -1439,43 +1439,30 @@ was slow and also confused users who didn't expect laziness.
 
 ** DNS Resolution
 
-Users may add their own DNS resolver function to override the OS provided DNS resolver. This is useful in situations where you are unable to change the name to IP Address mapping. It is analogus to the --reslove flag present in cUrl. This example uses the org.apache.http.impl.conn.InMemoryDnsResolver to allow resolution of example.com to IP Address 127.0.0.1. 
+Users may add their own DNS resolver function to override the default DNS Resolver. This is useful in situations where you are unable to change the name to IP Address mapping. It is analogous to the =--resolve= flag present in =curl=. This example uses =org.apache.http.impl.conn.InMemoryDnsResolver= to resolve =example.com= to IP Address =127.0.0.1=. 
 
 #+BEGIN_SRC clojure
-(client/get "https://example.com" {:keystore "/path/to/keystore.ks"
-                                   :keystore-type "jks" ; default: jks
-                                   :keystore-pass "secretpass"
-                                   :trust-store "/path/to/trust-store.ks"
-                                   :trust-store-type "jks" ; default jks
-                                   :trust-store-pass "trustpass"
-                                   :dns-resolver (doto (InMemoryDnsResolver.)
+(client/get "https://example.com" {:dns-resolver (doto (InMemoryDnsResolver.)
                                                    (.add "example.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})
 #+END_SRC
 
-This option is supported for all of the connection managers. You are free to implement any DnsResolver function you like. Here is a more Clojuresq example of a DnsResolver that attempts to look up the hostname in the supplied map and if it is not found passes it on to the system DNS resolver. Note how IPV6 addresses are specified.
+This option is supported for all of the connection managers.
+
+The =dns-resolver= can be any instance of =DnsResolver=. Here is an example of a custom implementation that attempts to look up the hostname in the supplied map and falls back to the default SystemDnsResolver if not found. Note how IPV6 addresses are specified.
 
 #+BEGIN_SRC clojure
 (defn custom-dns-resolver
-  "Given a map with a string hostname key and a byte array ip address vector [10 10 22 1] {\"foobar.com\" [127 0 0 1] ...}
-   and when the :custom-dns-resolver is added to the options use the function to override normal DNS resolution. Useful when
-   testing when you dont have write permissions to a /etc/hosts file and you need to use TLS with SNI (server name indication).
-   Uses the system resolver if the :server-name is not found in the supplied map."
   [host-map]
-  (reify
-    DnsResolver
-    (^"[Ljava.net.InetAddress;" resolve [this ^String host]
-     (if (contains? host-map host)
-       (into-array [(InetAddress/getByAddress host (byte-array (get host-map host)))])
-       (.resolve (SystemDefaultDnsResolver.) host)))))Editing clj-http_README.org at 3.x · fhitchen_clj-http
+  (let [system-dns-resolver (org.apache.http.impl.conn.SystemDefaultDnsResolver.)]
+    (reify
+      org.apache.http.conn.DnsResolver
+      (^"[Ljava.net.InetAddress;" resolve [this ^String host]
+       (if-let [address (get host-map host)]
+         (into-array [(java.net.InetAddress/getByAddress host (byte-array address))])
+         (.resolve system-dns-resolver host))))))
        
-(client/get "https://example.com" {:keystore "/path/to/keystore.ks"
-                                   :keystore-type "jks" ; default: jks
-                                   :keystore-pass "secretpass"
-                                   :trust-store "/path/to/trust-store.ks"
-                                   :trust-store-type "jks" ; default jks
-                                   :trust-store-pass "trustpass"
-                                   :dns-resolver (custom-dns-resolver {"example.com" [127 0 0 1]
-                                                                       "www.google.com" [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]})})
+(client/get "https://example.com" {:dns-resolver (custom-dns-resolver {"example.com" [127 0 0 1]
+                                                                        "www.google.com" [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]})})
 #+END_SRC
        
 

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -241,19 +241,19 @@
                        (or key-managers trust-managers)
                        (BasicHttpClientConnectionManager. (get-managers-scheme-registry req)
                                                           nil nil
-                                                          (when dns-resolver dns-resolver))
+                                                          dns-resolver)
 
                        (or keystore trust-store)
                        (BasicHttpClientConnectionManager. (get-keystore-scheme-registry req)
                                                           nil nil
-                                                          (when dns-resolver dns-resolver))
+                                                          dns-resolver)
 
                        (opt req :insecure) (BasicHttpClientConnectionManager.
                                             @insecure-scheme-registry nil nil
-                                            (when dns-resolver dns-resolver))
+                                            dns-resolver)
 
                        :else (BasicHttpClientConnectionManager. @regular-scheme-registry nil nil
-                                                                (when dns-resolver dns-resolver)))]
+                                                                dns-resolver))]
     (when socket-timeout
       (.setSocketConfig conn-manager
                         (-> (.getSocketConfig conn-manager)
@@ -323,7 +323,7 @@
 
                    :else @regular-scheme-registry)]
     (PoolingHttpClientConnectionManager.
-     registry nil nil (when dns-resolver dns-resolver) timeout java.util.concurrent.TimeUnit/SECONDS)))
+     registry nil nil dns-resolver timeout java.util.concurrent.TimeUnit/SECONDS)))
 
 (defn reusable? [conn-mgr]
   (or (instance? PoolingHttpClientConnectionManager conn-mgr)
@@ -350,6 +350,8 @@
 
   :key-managers - KeyManager objects to be used for connection manager
   :trust-managers - TrustManager objects to be used for connection manager
+
+  :dns-resolver - Use a custom DNS resolver instead of the default DNS resolver.
 
   Note that :insecure? and :keystore/:trust-store/:key-managers/:trust-managers options are mutually exclusive
 
@@ -392,7 +394,7 @@
                                                         ConnectionConfig/DEFAULT)]
     (future (.execute io-reactor io-event-dispatch))
     (proxy [PoolingNHttpClientConnectionManager ReuseableAsyncConnectionManager]
-        [io-reactor nil registry nil (when dns-resolver dns-resolver) timeout
+        [io-reactor nil registry nil dns-resolver timeout
          java.util.concurrent.TimeUnit/SECONDS])))
 
 (defn ^PoolingNHttpClientConnectionManager make-reusable-async-conn-manager

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -44,7 +44,10 @@
   (when b
     (cond
       (instance? InputStream b)
-      (GZIPInputStream. b)
+      (try 
+        (GZIPInputStream. b)
+        (catch java.io.EOFException e
+          nil))
       :else
       (IOUtils/toByteArray (GZIPInputStream. (ByteArrayInputStream. b))))))
 

--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -44,10 +44,7 @@
   (when b
     (cond
       (instance? InputStream b)
-      (try 
-        (GZIPInputStream. b)
-        (catch java.io.EOFException e
-          nil))
+      (GZIPInputStream. b)
       :else
       (IOUtils/toByteArray (GZIPInputStream. (ByteArrayInputStream. b))))))
 

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -176,17 +176,20 @@
 
 (deftest ^:integration dns-resolver
   (run-server)
-  (let [resp (request {:request-method :get :uri "/get"
+  (let [custom-dns-resolver (doto (InMemoryDnsResolver.)
+                              (.add "foo.bar.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))
+        resp (request {:request-method :get :uri "/get"
                        :server-name "foo.bar.com"
-                       :dns-resolver (doto (InMemoryDnsResolver.)
-                                       (.add "foo.bar.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})]
+                       :dns-resolver custom-dns-resolver})]
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 
 (deftest ^:integration dns-resolver-reusable-connection-manager
   (run-server)
-  (let [cm (conn/make-reuseable-async-conn-manager {:dns-resolver (doto (InMemoryDnsResolver.)
-                                                                    (.add "totallynonexistant.google.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})
+  (let [custom-dns-resolver (doto (InMemoryDnsResolver.)
+                              (.add "totallynonexistant.google.com"
+                                    (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))
+        cm (conn/make-reuseable-async-conn-manager {:dns-resolver custom-dns-resolver})
         hc (core/build-async-http-client {} cm)]
     (client/get "http://totallynonexistant.google.com:18080/json"
                 {:connection-manager cm
@@ -197,8 +200,9 @@
                   (is (= 200 (:status resp)))
                   (is (= {:foo "bar"} (:body resp))))
                 (fn [e] (is false (str "failed with " e)))))
-  (let [cm (conn/make-reusable-conn-manager {:dns-resolver (doto (InMemoryDnsResolver.)
-                                                             (.add "nonexistant.google.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})
+  (let [custom-dns-resolver (doto (InMemoryDnsResolver.)
+                              (.add "nonexistant.google.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))
+        cm (conn/make-reusable-conn-manager {:dns-resolver custom-dns-resolver})
         hc (:http-client (client/get "http://nonexistant.google.com:18080/get"
                                      {:connection-manager cm}))
         resp (client/get "http://nonexistant.google.com:18080/json"
@@ -207,74 +211,6 @@
                           :as :json})]
     (is (= 200 (:status resp)))
     (is (= {:foo "bar"} (:body resp)))))
-        
-(deftest ^:integration dns-resolver-insecure
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get"
-                       :server-name "foo.bar.com"
-                       :insecure true
-                       :dns-resolver (doto (InMemoryDnsResolver.)
-                                       (.add "foo.bar.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))})]
-    (is (= 200 (:status resp)))
-    (is (= "get" (slurp-body resp)))))
-
-(defn custom-dns-resolver
-  "Given a map with a string hostname key and a byte array ip address vector [10 10 22 1] {\"foobar.com\" [127 0 0 1] ...}
-   and when the :custom-dns-resolver is added to the options use the function to override normal DNS resolution. Useful when
-   testing when you dont have write permissions to a /etc/hosts file and you need to use TLS with SNI (server name indication).
-   Uses the system resolver if the :server-name is not found in the supplied map."
-  [host-map]
-  (reify
-    DnsResolver
-    (^"[Ljava.net.InetAddress;" resolve [this ^String host]
-     (if (contains? host-map host)
-       (into-array [(InetAddress/getByAddress host (byte-array (get host-map host)))])
-       (.resolve (SystemDefaultDnsResolver.) host)))))
-
-(deftest ^:integration dns-resolver-custom
-  (run-server)
-  (let [resp (request {:request-method :get :uri "/get"
-                       :server-name "foo.bar.com"
-                       :insecure true
-                       :dns-resolver (custom-dns-resolver {"foo.bar.com" [127 0 0 1]
-                                                           "www.google.com" [127 0 0 1]})})]
-    (is (= 200 (:status resp)))
-    (is (= "get" (slurp-body resp)))))
-
-
-
-(defn ipv6-interfaces
-  "Return # of IPv6 interfaces"
-  []
-  (->> (enumeration-seq (NetworkInterface/getNetworkInterfaces))
-       (map #(.getInterfaceAddresses %))
-       (apply concat)
-       (map #(.getAddress %))
-       (filter #(instance? java.net.Inet6Address %))
-       (count)))
-
-(deftest ^:integration dns-resolver-ipv6
-  (if (<= (ipv6-interfaces) 0)
-    (println "IPv6 not enabled, skipping custom-dns-resolver-ipv6 test.")
-    (do
-      (run-server)
-      (let [resp (request {:request-method :get :uri "/get"
-                           :server-name "foo.bar.ipv6"
-                           :dns-resolver (doto (InMemoryDnsResolver.)
-                                           (.add "foo.bar.ipv6" (into-array[(InetAddress/getByAddress (byte-array [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]))])))})]
-        (is (= 200 (:status resp)))
-        (is (= "get" (slurp-body resp)))))))
-
-(deftest ^:integration dns-resolver-ipv6-custom
-  (if (<= (ipv6-interfaces) 0)
-    (println "IPv6 not enabled, skipping custom-dns-resolver-ipv6 test.")
-    (do
-      (run-server)
-      (let [resp (request {:request-method :get :uri "/get"
-                           :server-name "foo.bar.ipv6"
-                           :dns-resolver (custom-dns-resolver {"foo.bar.ipv6" [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]})})]
-        (is (= 200 (:status resp)))
-        (is (= "get" (slurp-body resp)))))))
 
 (deftest ^:integration save-request-option
   (run-server)

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -9,7 +9,7 @@
             [clojure.test :refer :all]
             [ring.adapter.jetty :as ring])
   (:import (java.io ByteArrayInputStream)
-           (java.net InetAddress NetworkInterface SocketTimeoutException)
+           (java.net InetAddress SocketTimeoutException)
            (java.util.concurrent TimeoutException TimeUnit)
            (org.apache.http.params CoreConnectionPNames CoreProtocolPNames)
            (org.apache.http.message BasicHeader BasicHeaderIterator)
@@ -17,7 +17,6 @@
            (org.apache.http.client.protocol HttpClientContext)
            (org.apache.http.client.config RequestConfig)
            (org.apache.http.client.params CookiePolicy ClientPNames)
-           (org.apache.http.conn DnsResolver)
            (org.apache.http.conn.util PublicSuffixMatcherLoader)
            (org.apache.http.cookie CommonCookieAttributeHandler)
            (org.apache.http HttpRequest HttpResponse HttpConnection
@@ -26,7 +25,7 @@
            (org.apache.http.impl.client DefaultHttpClient)
            (org.apache.http.impl.cookie RFC6265CookieSpec RFC6265CookieSpecProvider
                                         RFC6265CookieSpecProvider$CompatibilityLevel)
-           (org.apache.http.impl.conn InMemoryDnsResolver SystemDefaultDnsResolver)
+           (org.apache.http.impl.conn InMemoryDnsResolver)
            (org.apache.http.client.params ClientPNames)
            (org.apache.logging.log4j LogManager)
            (sun.security.provider.certpath SunCertPathBuilderException)))

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -183,6 +183,14 @@
     (is (= 200 (:status resp)))
     (is (= "get" (slurp-body resp)))))
 
+(deftest ^:integration dns-resolver-unknown-host
+  (run-server)
+  (let [custom-dns-resolver (doto (InMemoryDnsResolver.)
+                              (.add "foo.bar.com" (into-array[(InetAddress/getByAddress (byte-array [127 0 0 1]))])))]
+    (is (thrown? java.net.UnknownHostException (request {:request-method :get :uri "/get"
+                                                        :server-name "www.google.com"
+                                                        :dns-resolver custom-dns-resolver})))))
+
 (deftest ^:integration dns-resolver-reusable-connection-manager
   (run-server)
   (let [custom-dns-resolver (doto (InMemoryDnsResolver.)


### PR DESCRIPTION
Hi,
I have made the changes you suggested and put them in a new PR. The dns-resolver function is now removed from the clj-http code and users are free to provide their own DNS resolver. I have provided an example of a clojuresqe dns-resolver and one using the ugly org.apache.http.impl.conn.InMemoryDnsResolver.
Let me know what needs fixing.
I had to add the try catch to ZIP test as it fails all the time on my Ubuntu 20.04 server with OpenJDK 11 and with OracleJDK 1.8.0_252.
regards, Francis.