### PR TITLE
Fix performance regression related to #528

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -450,7 +450,7 @@
   (let [^BufferedReader br (io/reader (util/force-stream body))]
     (try
       (.mark br 1)
-      (let [^int first-char (try (.read br) (catch EOFException _ -1))]
+      (let [first-char (int (try (.read br) (catch EOFException _ -1)))]
         (case first-char
           -1 nil
           (do (.reset br)


### PR DESCRIPTION
As explained [here](https://github.com/dakrone/clj-http/issues/528#issuecomment-653022194) the previous fix for #528 was reverted, possible because of a bad merge.

This PR resolves the performance warning in same way as before: https://github.com/dakrone/clj-http/pull/532