### PR TITLE
Check first byte before gunzip

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -44,7 +44,12 @@
   (when b
     (cond
       (instance? InputStream b)
-      (GZIPInputStream. b)
+      (let [^PushbackInputStream b (PushbackInputStream. b)
+            first-byte (int (try (.read b) (catch EOFException _ -1)))]
+        (case first-byte
+          -1 b
+          (do (.unread b first-byte)
+              (GZIPInputStream. b))))
       :else
       (IOUtils/toByteArray (GZIPInputStream. (ByteArrayInputStream. b))))))
 

--- a/test/clj_http/test/util_test.clj
+++ b/test/clj_http/test/util_test.clj
@@ -53,3 +53,7 @@
       ;; coerce to seq to force byte-by-byte comparison
       (is (= (seq (IOUtils/toByteArray (io/input-stream jpg-path)))
              (seq (force-byte-array (io/input-stream jpg-path))))))))
+
+(deftest test-gunzip
+  (testing "with empty input, does not q gzip stream"
+    (is (nil? (force-byte-array (gunzip (force-stream (byte-array 0))))))))

--- a/test/clj_http/test/util_test.clj
+++ b/test/clj_http/test/util_test.clj
@@ -55,5 +55,10 @@
              (seq (force-byte-array (io/input-stream jpg-path))))))))
 
 (deftest test-gunzip
-  (testing "with empty input, does not q gzip stream"
-    (is (nil? (force-byte-array (gunzip (force-stream (byte-array 0))))))))
+  (testing "with input streams"
+    (testing "with empty stream, does not apply gunzip stream"
+      (is (= "" (slurp (gunzip (force-stream (byte-array 0)))))))
+    (testing "with non-empty stream, gunzip decompresses data"
+      (let [data "hello world"]
+        (is (= data
+               (slurp (gunzip (force-stream (gzip (.getBytes data)))))))))))


### PR DESCRIPTION
This change in behavior is a regression in the :integration suite since #521.