### PR TITLE
Properly handle "308 Permanent Redirect" status code

### DIFF
--- a/README.org
+++ b/README.org
@@ -704,7 +704,7 @@ APIs:
 
 clj-http conforms its behaviour regarding automatic redirects to the [[https://tools.ietf.org/html/rfc2616#section-10.3][RFC]].
 
-It means that redirects on status =301=, =302= and =307= are not redirected on
+It means that redirects on status =301=, =302=, =307= and =308= are not redirected on
 methods other than =GET= and =HEAD=. If you want a behaviour closer to what most
 browser have, you can set =:redirect-strategy= to =:lax= in your request to have
 automatic redirection work on all methods by transforming the method of the

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -196,7 +196,7 @@
 
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?
-  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})
+  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307 308})
 
 (defn unexceptional-status-for-request?
   [req status]
@@ -334,7 +334,7 @@
                          resp-r)
         :else
         (respond* resp-r req))
-      (= 307 status)
+      (#{307 308} status)
       (if (or (#{:get :head} request-method)
               (opt req :force-redirects))
         (follow-redirect client (assoc req :redirects-count

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -457,7 +457,7 @@
 
 (deftest pass-on-non-redirectable-methods
   (doseq [method [:put :post :delete]
-          status [301 302 307]]
+          status [301 302 307 308]]
     (let [client (fn [req] {:status status :body (:body req)
                            :headers {"location" "http://example.com/bat"}})
           r-client (client/wrap-redirects client)
@@ -470,7 +470,7 @@
 
 (deftest pass-on-non-redirectable-methods-async
   (doseq [method [:put :post :delete]
-          status [301 302 307]]
+          status [301 302 307 308]]
     (let [client (fn [req respond raise]
                    (respond {:status status :body (:body req)
                              :headers {"location" "http://example.com/bat"}}))


### PR DESCRIPTION
Based on https://tools.ietf.org/html/rfc7538#section-3, "308 Permanent Redirect" status code is a permanent counterpart of status code 307 thus should be handled similarly.