### PR TITLE
Make CookieSpecs/STANDARD the default cookie spec

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -171,7 +171,7 @@
 (defmethod get-cookie-policy :default default-cookie-policy
   [_] CookieSpecs/DEFAULT)
 (defmethod get-cookie-policy nil nil-cookie-policy
-  [_] CookieSpecs/DEFAULT)
+  [_] CookieSpecs/STANDARD)
 (defmethod get-cookie-policy :netscape netscape-cookie-policy
   [_] CookieSpecs/NETSCAPE)
 (defmethod get-cookie-policy :standard standard-cookie-policy


### PR DESCRIPTION
Reasoning
---------
The Apache HTTP Client documentation has this to say about the DEFAULT
cookie spec:

"This policy will be deprecated in favor of the standard (RFC 6265
compliant) implementation in the next minor release of HttpClient."
(https://hc.apache.org/httpcomponents-client-ga/tutorial/html/statemgmt.html)

The same document then states: "It is strongly recommended to use
either Standard or Standard strict policy in new applications."

This change makes CookieSpecs/STANDARD the default for the
get-cookie-policy multimethod.