### PR TITLE
Update installation instructions to latest version

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,7 +122,7 @@ function.
 With Leiningen/Boot:
 
 #+BEGIN_SRC clojure
-[clj-http "3.10.1"]
+[clj-http "3.10.2"]
 #+END_SRC
 
 If you need an older version, a 2.x release is also available.


### PR DESCRIPTION
While setting up a new clojure project I just noticed that the version in the README is not the latest version