### PR TITLE
Improve error message when using incompatible version of cheshire (< 5.9.0)

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -23,7 +23,9 @@ List of user-visible changes that have gone into each release
 - Bug fix: Check first byte before wrapping response stream with gunzip
   https://github.com/dakrone/clj-http/pull/549
 ** 3.10.1
-- JSON parsing is always strict. See [[file:README.org::*Incrementally%20JSON%20Parsing][README#Incrementally JSON Parsing]]. Requires cheshire >= 5.9.0.
+- JSON parsing is always strict. See [[file:README.org::*Incrementally%20JSON%20Parsing][README#Incrementally JSON Parsing]]. This is
+  a *breaking change* and users *must* upgrade to cheshire >= 5.9.0.
+  https://github.com/dakrone/clj-http/pull/507
 ** 3.10.0
 - Add trust-manager and key-managers support to the client
   https://github.com/dakrone/clj-http/pull/469

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -128,7 +128,10 @@
   "Resolve and apply cheshire's json decoding dynamically."
   [& args]
   {:pre [json-enabled?]}
-  (apply (ns-resolve (symbol "cheshire.core") (symbol "parse-stream-strict")) args))
+  (if-let [json-decode-fn (ns-resolve (symbol "cheshire.core") (symbol "parse-stream-strict"))]
+    (apply json-decode-fn args)
+    (throw
+     (IllegalStateException. "Missing #'cheshire.core/parse-stream-strict. Ensure the version of `cheshire` is >= 5.9.0"))))
 
 (defn ^:dynamic form-decode
   "Resolve and apply ring-codec's form decoding dynamically."


### PR DESCRIPTION
The json-decode change in `v3.10.1` requires cheshire >= 5.9.0. When users do not
upgrade cheshire, they will see a very unhelpful error similar to this.

    Syntax error (NullPointerException) compiling at (...)

This change introduces a slightly more helpful error message to point users at
how to resolve this issue.

Fixes #555