### PR TITLE
Enumerated multi-param-style added

### DIFF
--- a/README.org
+++ b/README.org
@@ -593,13 +593,14 @@ disabled by using with-middleware to specify different behavior.
 :CUSTOM_ID: h-dd49992c-a516-4af0-9735-4f4340773361
 :END:
 
-There are three different ways that query string parameters for array values can
+There are four different ways that query string parameters for array values can
 be generated, depending on what the resulting query string should look like,
 they are:
 
 - A repeating parameter (default)
 - Array style
 - Indexed array style
+- Enumerated style
 
 Here is an example of the input and output for the ~:query-params~ parameter,
 controlled by the ~:multi-param-style~ option:
@@ -613,6 +614,8 @@ controlled by the ~:multi-param-style~ option:
 ;; with :multi-param-style :indexed, a repeating param with array suffix and
 ;; index (Rails-style):
 :a [1 2 3] => "a[0]=1&a[1]=2&a[2]=3"
+;; with :multi-param-style :enumerated, a param with enumerated values
+:a [1 2 3] => "a=1,2,3"
 #+END_SRC
 
 ** Meta Tag Headers

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -765,7 +765,7 @@
   (let [key (util/url-encode (name key) encoding)
         values (map #(util/url-encode (str %) encoding) values)]
     (case multi-param-style
-      :index
+      :indexed
       (map-indexed #(vector (str key \[ %1 \]) %2) values)
 
       :array

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -771,11 +771,18 @@
   (str/join "&"
             (mapcat (fn [[k v]]
                       (if (sequential? v)
-                        (map-indexed
-                         #(str (util/url-encode (name k) encoding)
-                               (multi-param-suffix %1 multi-param-style)
-                               "="
-                               (util/url-encode (str %2) encoding)) v)
+                        (cond
+                          (= multi-param-style :enumerated)
+                          [(str (util/url-encode (name k) encoding)
+                              "="
+                              (str/join "," (map #(util/url-encode (str %) encoding) v)))]
+                          
+                          :else
+                          (map-indexed
+                           #(str (util/url-encode (name k) encoding)
+                                 (multi-param-suffix %1 multi-param-style)
+                                 "="
+                                 (util/url-encode (str %2) encoding)) v))
                         [(str (util/url-encode (name k) encoding)
                               "="
                               (util/url-encode (str v) encoding))]))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1667,7 +1667,17 @@
           query-string (-> resp :body form-decode-str)]
       (is (= 200 (:status resp)))
       (is (.contains query-string "a[]=1&a[]=2&a[]=3") query-string)
-      (is (.contains query-string "b[]=x&b[]=y&b[]=z") query-string))))
+      (is (.contains query-string "b[]=x&b[]=y&b[]=z") query-string)))
+  (testing "multi-valued query params in enumerated-style"
+    (let [resp (request {:uri "/query-string"
+                         :method :get
+                         :multi-param-style :enumerated
+                         :query-params {:a [1 2 3]
+                                        :b ["x" "y" "z"]}})
+          query-string (-> resp :body form-decode-str)]
+      (is (= 200 (:status resp)))
+      (is (.contains query-string "a=1,2,3") query-string)
+      (is (.contains query-string "b=x,y,z") query-string))))
 
 (deftest t-wrap-flatten-nested-params
   (is-applied client/wrap-flatten-nested-params


### PR DESCRIPTION
This patch adds a fourth way to represent arrays/vectors in an url, as described on [this Website](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Best-Practices-for-Parameters-and-Query-String-Usage/).