### PR TITLE
Close transit input stream after reading response

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -485,7 +485,8 @@
   {:pre [transit-enabled?]}
   (let [charset (or charset (response-charset resp))
         body (if (can-parse-body? request resp)
-               (parse-transit (util/force-stream body) type transit-opts)
+               (with-open [in (util/force-stream body)]
+                 (parse-transit in type transit-opts))
                (util/force-string body charset))]
     (assoc resp :body body)))
 


### PR DESCRIPTION
Connections are not closing immediately after coercing the body using transit. This is a regression introduced in https://github.com/dakrone/clj-http/pull/475. Previously, the response body always was also transferred into an intermediate byte-array which will read bytes until the stream is empty, and automatically close the connection.

Since we no longer have this implicit behavior, the body coercion middleware must close the inputstream after reading a value.

Fixes #564

## Testing Notes

REPL Output showing connection closing *after* the change:
 
``` clojure
> (clj-http.client/get "http://localhost:18080/transit-json" {:as :transit+json})
2020-09-27 12:46:51,569 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.BasicHttpClientConnectionManager | Get connection for route {}->http://localhost:18080
2020-09-27 12:46:51,570 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.DefaultManagedHttpClientConnection | http-outgoing-6: set socket timeout to 0
2020-09-27 12:46:51,571 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.DefaultHttpClientConnectionOperator | Connecting to localhost/127.0.0.1:18080
2020-09-27 12:46:51,572 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.DefaultHttpClientConnectionOperator | Connection established 127.0.0.1:51715<->127.0.0.1:18080
2020-09-27 12:46:51,573 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "GET /transit-json HTTP/1.1[\r][\n]"
2020-09-27 12:46:51,573 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "Connection: close[\r][\n]"
2020-09-27 12:46:51,574 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "accept-encoding: gzip, deflate[\r][\n]"
2020-09-27 12:46:51,574 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "Host: localhost:18080[\r][\n]"
2020-09-27 12:46:51,575 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "User-Agent: Apache-HttpClient/4.5.10 (Java/11.0.8)[\r][\n]"
2020-09-27 12:46:51,575 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 >> "[\r][\n]"
2020-09-27 12:46:51,577 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "HTTP/1.1 200 OK[\r][\n]"
2020-09-27 12:46:51,578 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "Connection: close[\r][\n]"
2020-09-27 12:46:51,578 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "Date: Sun, 27 Sep 2020 19:46:51 GMT[\r][\n]"
2020-09-27 12:46:51,579 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "Content-Type: application/transit+json[\r][\n]"
2020-09-27 12:46:51,579 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "Content-Length: 81[\r][\n]"
2020-09-27 12:46:51,580 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "Server: Jetty(9.4.12.v20180830)[\r][\n]"
2020-09-27 12:46:51,580 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "[\r][\n]"
2020-09-27 12:46:51,581 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.wire | http-outgoing-6 << "["^ ","~:eggplant",["^ ","~:quux",["~#set",[1,3,2]]],"~:baz","~f7","~:foo","bar"]"
2020-09-27 12:46:51,585 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.DefaultManagedHttpClientConnection | http-outgoing-6: Close connection
2020-09-27 12:46:51,586 | DEBUG | [nREPL-session-10c7ac57-6d4c-4bba-a1a8-8b5feace8191] | org.apache.http.impl.conn.BasicHttpClientConnectionManager | Releasing connection [Not bound]
```