### PR TITLE
rename `exceptional-status` from `unexceptional-status`

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -237,7 +237,7 @@
     resp
     (if (false? (opt req :throw-exceptions))
       resp
-      (let [data (assoc resp :type ::unexceptional-status)]
+      (let [data (assoc resp :type ::exceptional-status)]
         (if (opt req :throw-entire-message)
           (throw+ data "clj-http: status %d %s" (:status %) resp)
           (throw+ data "clj-http: status %s" (:status %)))))))

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -569,7 +569,7 @@
         e-client (client/wrap-exceptions client)]
     (try+
      (e-client {})
-     (catch [:type :clj-http.client/unexceptional-status] _
+     (catch [:type :clj-http.client/exceptional-status] _
        (is true))
      (catch Object _
        (is false ":type selector was not caught.")))))


### PR DESCRIPTION
According to what was discussed on https://github.com/dakrone/clj-http/issues/563, this Pull Request renames `unexceptional-status` to `exceptional-status` when adding a `:type` to the exception.