### PR TITLE
Bump patch versions of apache httpcomponents to latest.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,11 +7,11 @@
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.0.0"
   :exclusions [org.clojure/clojure]
-  :dependencies [[org.apache.httpcomponents/httpcore "4.4.12"]
-                 [org.apache.httpcomponents/httpclient "4.5.10"]
-                 [org.apache.httpcomponents/httpclient-cache "4.5.10"]
+  :dependencies [[org.apache.httpcomponents/httpcore "4.4.13"]
+                 [org.apache.httpcomponents/httpclient "4.5.13"]
+                 [org.apache.httpcomponents/httpclient-cache "4.5.13"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.4"]
-                 [org.apache.httpcomponents/httpmime "4.5.10"]
+                 [org.apache.httpcomponents/httpmime "4.5.13"]
                  [commons-codec "1.12"]
                  [commons-io "2.6"]
                  [slingshot "0.12.2"]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1886587.

Technically, only the upgrade to apache-httpclient is necessary to fix
this violation but it seems prudent to update the other components to
the same version to ensure that they work together nicely..