### PR TITLE
Handle quoted parameter values in content type

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -145,15 +145,17 @@
         false
         (or v1 v2)))))
 
+(defn- trim-quotes [s]
+  (clojure.string/replace s #"^\s*(\"(.*)\"|(.*?))\s*$" "$2$3"))
+
 (defn parse-content-type
   "Parse `s` as an RFC 2616 media type."
   [s]
-  (if-let [m (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
+  (when-let [m (re-matches #"\s*(([^/]+)/([^ ;]+))\s*(\s*;.*)?" (str s))]
     {:content-type (keyword (nth m 1))
      :content-type-params
      (->> (split (str (nth m 4)) #"\s*;\s*")
-          (identity)
           (remove blank?)
           (map #(split % #"="))
-          (mapcat (fn [[k v]] [(keyword (lower-case k)) (trim v)]))
+          (mapcat (fn [[k v]] [(keyword (lower-case k)) (trim-quotes v)]))
           (apply hash-map))}))

--- a/test/clj_http/test/util_test.clj
+++ b/test/clj_http/test/util_test.clj
@@ -41,6 +41,9 @@
     " application/json;  charset=UTF-8 "
     {:content-type :application/json
      :content-type-params {:charset "UTF-8"}}
+    " application/json;  charset=\"utf-8\" "
+    {:content-type :application/json
+     :content-type-params {:charset "utf-8"}}
     "text/html; charset=ISO-8859-4"
     {:content-type :text/html
      :content-type-params {:charset "ISO-8859-4"}}))


### PR DESCRIPTION
The following request fails for me: `(clj-http.client/get "https://facebook.com" {:as :reader})` with the unrecognized encoding exception. That's because the content type header for facebook is set to `text/html; charset="utf-8"`, and clj-http doesn't support quoted strings for charset. RFC 2616 allows quoted strings there, this PR fixes that. I added one test for this case and ran all the tests with `lein all test :all`.