### PR TITLE
core/request-config, normalizeUri bug fix

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -160,10 +160,10 @@
                               socket-timeout
                               max-redirects
                               cookie-spec
+                              normalize-uri
                               ; deprecated
                               conn-request-timeout
-                              conn-timeout
-                              normalize-uri]
+                              conn-timeout]
                        :as req}]
   (let [config (-> (RequestConfig/custom)
                    (.setConnectTimeout (or connection-timeout conn-timeout -1))
@@ -175,12 +175,12 @@
                     (boolean (opt req :allow-circular-redirects)))
                    (.setRelativeRedirectsAllowed
                     ((complement false?)
-                     (opt req :allow-relative-redirects)))
-                   (.setNormalizeUri (or normalize-uri true)))]
+                     (opt req :allow-relative-redirects))))]
     (if cookie-spec
       (.setCookieSpec config CUSTOM_COOKIE_POLICY)
       (.setCookieSpec config (get-cookie-policy req)))
     (when max-redirects (.setMaxRedirects config max-redirects))
+    (when-not (nil? normalize-uri) (.setNormalizeUri config normalize-uri))
     (.build config)))
 
 (defmulti ^:private construct-http-host (fn [proxy-host proxy-port]

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -744,6 +744,23 @@
 
     (is (= (:trace-redirects resp-without-redirects) []))))
 
+(deftest t-request-config
+  (let [params {:conn-timeout 100 ;; deprecated
+                :connection-timeout 200 ;; takes precedence over `:conn-timeout`
+                :conn-request-timeout 300 ;; deprecated
+                :connection-request-timeout 400 ;; takes precedence over `:conn-request-timeout`
+                :socket-timeout 500
+                :max-redirects 600
+                :cookie-spec "foo"                              
+                :normalize-uri false}
+        request-config (core/request-config params)]
+    (is (= 200 (.getConnectTimeout request-config)))
+    (is (= 400 (.getConnectionRequestTimeout request-config)))
+    (is (= 500 (.getSocketTimeout request-config)))
+    (is (= 600 (.getMaxRedirects request-config)))
+    (is (= core/CUSTOM_COOKIE_POLICY (.getCookieSpec request-config)))
+    (is (false? (.isNormalizeUri request-config)))))
+
 (deftest ^:integration t-override-request-config
   (run-server)
   (let [called-args (atom [])


### PR DESCRIPTION
* core/request-config, fixes incorrect `setNormalizeUri`.
* adds test for core/request-config