### PR TITLE
Bump httpcore to version 4.4.14

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.0.0"
   :exclusions [org.clojure/clojure]
-  :dependencies [[org.apache.httpcomponents/httpcore "4.4.13"]
+  :dependencies [[org.apache.httpcomponents/httpcore "4.4.14"]
                  [org.apache.httpcomponents/httpclient "4.5.13"]
                  [org.apache.httpcomponents/httpclient-cache "4.5.13"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.4"]


### PR DESCRIPTION
According to the official changelog:

> 1 December 2020 - HttpComponents Core 4.4.14 (GA) released

> This is a maintenance release that corrects a number of defects discovered since release 4.4.13 including two defects in the async (non-blocking) transport potentially causing an infinite event loop and and excessive CPU utilization.﻿
