### PR TITLE
allow http-client re-use in async situation

### DIFF
--- a/src/clj_http/core.clj
+++ b/src/clj_http/core.clj
@@ -625,7 +625,8 @@
                (conn/shutdown-manager conn-mgr))
              (throw t))))
        (let [^CloseableHttpAsyncClient client
-             (build-async-http-client req conn-mgr http-url proxy-ignore-hosts)
+             (or http-client
+                 (build-async-http-client req conn-mgr http-url proxy-ignore-hosts))
              original-thread-bindings (clojure.lang.Var/getThreadBindingFrame)]
          (when cache?
            (throw (IllegalArgumentException.

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -883,7 +883,9 @@
                  :async true}
                 (fn [resp]
                   (is (= 200 (:status resp)))
-                  (is (= {:foo "bar"} (:body resp))))
+                  (is (= {:foo "bar"} (:body resp)))
+                  (is (= hc (:http-client resp))
+                      "http-client is correctly reused"))
                 (fn [e] (is false (str "failed with " e)))))
   (let [cm (conn/make-reusable-conn-manager {})
         hc (:http-client (client/get (localhost "/get")
@@ -893,7 +895,9 @@
                           :http-client hc
                           :as :json})]
     (is (= 200 (:status resp)))
-    (is (= {:foo "bar"} (:body resp)))))
+    (is (= {:foo "bar"} (:body resp)))
+    (is (= hc (:http-client resp))
+        "http-client is correctly reused")))
 
 (deftest ^:integration t-cookies-spec
   (run-server)


### PR DESCRIPTION
This is a revival of #458 with the completion of unit tests to ensure http-client are reused (both in sync & async contexts).

I have cherry-picked the original commit from #458 and had to adapt it as it had conflicts. Unfortunately it did not keep the original author :cry: .