### PR TITLE
Fix #609: Fix reading Transit response stream if data isn't available…

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -101,10 +101,15 @@
   "Resolve and apply Transit's JSON/MessagePack decoding."
   [^InputStream in type & [opts]]
   {:pre [transit-enabled?]}
-  (when (pos? (.available in))
+  (try
     (let [reader (ns-resolve 'cognitect.transit 'reader)
           read (ns-resolve 'cognitect.transit 'read)]
-      (read (reader in type (transit-read-opts opts))))))
+      (read (reader in type (transit-read-opts opts))))
+    (catch RuntimeException e
+      ;; Ignore exceptions from trying to read an empty stream.
+      (if (instance? EOFException (.getCause e))
+        nil
+        (throw e)))))
 
 (defn ^:dynamic transit-encode
   "Resolve and apply Transit's JSON/MessagePack encoding."

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -12,6 +12,8 @@
             [ring.util.codec :refer [form-decode-str]]
             [slingshot.slingshot :refer [try+]])
   (:import java.io.ByteArrayInputStream
+           java.io.PipedInputStream
+           java.io.PipedOutputStream
            java.net.UnknownHostException
            org.apache.http.HttpEntity
            org.apache.logging.log4j.LogManager))
@@ -1754,3 +1756,36 @@
       (is (= (.getMessage e)
              (str "only :flatten-nested-keys or :ignore-nested-query-string/"
                   ":flatten-nested-keys may be specified, not both"))))))
+
+(defn transit-resp [body]
+  {:body body
+   :status 200
+   :headers {"content-type" "application/transit-json"}})
+
+(deftest issue-609-empty-transit-response
+  (testing "Body is available right away"
+    (is (= {:foo "bar"}
+           (:body (client/coerce-response-body
+                    {:as :transit+json}
+                    (transit-resp (ByteArrayInputStream.
+                                    (.getBytes "[\"^ \",\"~:foo\",\"bar\"]"))))))))
+
+  (testing "Empty body is read as nil"
+    (is (nil? (:body (client/coerce-response-body
+                       {:as :transit+json}
+                       (transit-resp (ByteArrayInputStream. (.getBytes ""))))))))
+
+  (testing "Body is read correctly even if the data becomes available later"
+    ;; Ensure both streams are closed (normally done inside future).
+    (with-open [o (PipedOutputStream.)
+                i (PipedInputStream.)]
+      (.connect i o)
+      (future
+        (Thread/sleep 10)
+        (.write o (.getBytes "[\"^ \",\"~:foo\",\"bar\"]"))
+        ;; Close right now, with-open will wait until test is done.
+        (.close o))
+      (is (= {:foo "bar"}
+             (:body (client/coerce-response-body
+                      {:as :transit+json}
+                      (transit-resp i))))))))


### PR DESCRIPTION
… right-away

InputStream .available only checks if data is available to read right
now. It is possible that data becomes available leter. Read method (used
by Transit internally) will block untill data is available or the stream
is closed.

It is best to let Transit read the stream. Empty streams throws an
exception with Transit, but we can catch that specific case and return
nil like previously.

Two test cases test the existing functionality, and third new test case
checks that Transit data is read correctly when the data becomes
available a bit later.