### PR TITLE
Allow overriding of the file name in multi part uploads

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -31,22 +31,22 @@
 
 (defmethod make-multipart-body File
   ;; Create a FileBody object from the given map, requiring at least :content
-  [{:keys [^String name ^String mime-type ^File content ^String encoding]}]
+  [{:keys [^String name ^String mime-type ^File content ^String encoding ^String file-name]}]
   (cond
     (and name mime-type content encoding)
-    (FileBody. content (ContentType/create mime-type encoding) name)
+    (FileBody. content (ContentType/create mime-type encoding) (or file-name name))
 
     (and mime-type content encoding)
-    (FileBody. content (ContentType/create mime-type encoding))
+    (FileBody. content (ContentType/create mime-type encoding) file-name)
 
     (and name mime-type content)
-    (FileBody. content (ContentType/create mime-type) name)
+    (FileBody. content (ContentType/create mime-type) (or file-name name))
 
     (and mime-type content)
-    (FileBody. content (ContentType/create mime-type))
+    (FileBody. content (ContentType/create mime-type) file-name)
 
     content
-    (FileBody. content)
+    (FileBody. content nil file-name)
 
     :else
     (throw (Exception. "Multipart file body must contain at least :content"))))

--- a/test/clj_http/test/multipart_test.clj
+++ b/test/clj_http/test/multipart_test.clj
@@ -172,7 +172,16 @@
         (is (= "file-body" (body-mime-type body)))
         (is (= (Charset/forName "ascii") (body-charset body)))
         (is (= test-file (.getFile body) ))
-        (is (= "testname" (.getFilename body)))))))
+        (is (= "testname" (.getFilename body)))))
+
+    (testing "the :file-name key overrides the :name key"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content   test-file
+                                       :name      "testname"
+                                       :file-name "foo.txt"})]
+        (is (instance? FileBody body))
+        (is (= test-file (.getFile body) ))
+        (is (= "foo.txt" (.getFilename body)))))))
 
 (deftest test-multipart-content-charset
   (testing "charset is nil if no multipart-charset is supplied"


### PR DESCRIPTION
# The Problem

I have to interact with a hateful API which expects a file uploaded as part of a multi-part field, where both the multi-part field and the file name have to be a specific value:


```clojure
(let [file (io/file "foo.txt")]
  (client/post "https://hateful.io"
               {:multipart [{:name "special-snowflake", :content file}]}))
;; => 200

(let [file (io/file "foo.txt")]
  (client/post "https://hateful.io"
               {:multipart [{:name "something-else", :content file}]}))
;; => 400 "Expected multi-part field "special-snowflake" but didn't find it"

(let [file (io/file "foo.txt")
      other-file (io/file "bar.txt")]
  (io/copy file other-file)
  (client/post "https://hateful.io"
               {:multipart [{:name "special-snowflake", :content other-file}]}))
;; => 400 Expected file in the "special-snowflake" field to be called "foo.txt"

```

This is inconvenient in a server context, because I cannot safely use `java.io.File/createTempFile`, because it dynamically generates file names in order to avoid race conditions.

# What I did instead

Something sad:

```clojure

(defn- with-name-override
  [file file-name]
  (with-meta {:file file, :name file-name} {:type :file-with-name-override}))

(defmethod make-multipart-body :file-with-name-override
  [{:keys [name content]}]
  (if (and name content)
    (FileBody. (:file content)
               ContentType/APPLICATION_OCTET_STREAM
               (:name file-name))
    (throw
      (Exception.
        "Multipart :file-with-name-override must contain :name and :content"))))

(let [file (io/file "foo.txt")
      temp-file (with-name-override (File/createTempFile "foo" ".txt")
                                     "foo.txt")]
  (io/copy file (:file temp-file))
  (client/post "https://hateful.io"
               {:multipart [{:name "special-snowflake", :content temp-file}]}))

```

# Proposed Enhancement

Allow a `:file-name` key in multipart field arguments, which overrides the name of the file if specified.