### PR TITLE
add documentation on proxy credentials

### DIFF
--- a/README.org
+++ b/README.org
@@ -1304,6 +1304,12 @@ Additionally, per-request proxies can be specified with the =proxy-host= and
 (client/get "http://example.com" {:proxy-host "127.0.0.1" :proxy-port 8118})
 #+END_SRC
 
+Proxy credentials can also be explicitly set as
+
+#+BEGIN_SRC clojure
+(client/get "http://example.com" {:proxy-host "127.0.0.1" :proxy-port 8118 :proxy-user "proxy-user" :proxy-pass "superSecurePassword"})
+#+END_SRC
+
 You can also specify the =proxy-ignore-hosts= parameter with a list of
 hosts where the proxy should be ignored. By default this list is
 =#{"localhost" "127.0.0.1"}=.


### PR DESCRIPTION
Minor Documentation addition
I see support for proxy credentials is already present, but it isn't obvious until i spent some time combing through issues and the codebase.

This is an attempt at making it more accessible in the future
@dakrone 