### PR TITLE
Add ability to set custom boundary for multipart entity

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -144,12 +144,13 @@
 (defn create-multipart-entity
   "Takes a multipart vector of maps and creates a MultipartEntity with each
   map added as a part, depending on the type of content."
-  [multipart {:keys [mime-subtype multipart-mode multipart-charset]
+  [multipart {:keys [mime-subtype multipart-mode multipart-charset boundary]
               :or {mime-subtype "form-data"
                    multipart-mode HttpMultipartMode/STRICT}}]
   (let [mp-entity (doto (MultipartEntityBuilder/create)
                     (.setMode multipart-mode)
                     (.setMimeSubtype mime-subtype))]
+    (when boundary (.setBoundary mp-entity boundary))
     (when multipart-charset
       (.setCharset mp-entity (encoding-to-charset multipart-charset)))
     (doseq [m multipart]

--- a/test/clj_http/test/multipart_test.clj
+++ b/test/clj_http/test/multipart_test.clj
@@ -181,3 +181,12 @@
   (testing "charset is set if a multipart-charset is supplied"
     (let [mp-entity (create-multipart-entity [] {:multipart-charset "UTF-8"})]
       (is (= "UTF-8" (EntityUtils/getContentCharSet mp-entity))))))
+
+(deftest test-multipart-boundary
+  (testing "default random boundary is set when no custom boundary is supplied"
+    (let [mp-entity (create-multipart-entity [] {})]
+      (is (re-matches #"--.+--\r\n" (-> mp-entity .getContent slurp)))))
+
+  (testing "custom boundary is set when custom boundary is supplied"
+    (let [mp-entity (create-multipart-entity [] {:boundary "CustomMultipartBoundary"})]
+      (is (re-matches #"--CustomMultipartBoundary--\r\n" (-> mp-entity .getContent slurp))))))


### PR DESCRIPTION
# Why

There is a lot of weird APIs in the wild and to use some of them we need to know our MultiPart boundary. The easiest way to obtain this knowledge is to set this boundary manually ourselves. So please accept my small improvement that allows to do just that.

# Tests

Can't run `lein all test :all` for a reason described in #618. It doesn't seem to be related to my changes anyhow though.

However, `lein test clj-http.test.multipart-test` runs without errors:

```bash
$ lein test clj-http.test.multipart-test

Ran 3 tests containing 55 assertions.
0 failures, 0 errors.
```