### PR TITLE
Add transit to README optional deps.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1506,6 +1506,7 @@ adding them with the clj-http dependency in your project.clj:
 [crouton] ;; for :decode-body-headers
 [org.clojure/tools.reader] ;; for :as :clojure
 [ring/ring-codec] ;; for :as :x-www-form-urlencoded
+[com.cognitect/transit-clj] ;; for transit support
 #+END_SRC
 
 Prior to 2.0.0, you can /exclude/ the dependencies and clj-http will work


### PR DESCRIPTION
Maybe I'm misunderstanding something about the optional deps, but I also don't understand why this section is under `Development`. Don't all users who want to use one of these optional deps need to know to include the dep in their dependency management tool?