### PR TITLE
Add note about :content-type encoding

### DIFF
--- a/README.org
+++ b/README.org
@@ -315,6 +315,8 @@ content encodings.
 :CUSTOM_ID: h-32c8ca7a-0ef2-41b8-8158-20b0e2945e5d
 :END:
 
+Note that =:content-type= encoding only works when using =:form-params=. =:body= values are not encoded.
+
 #+BEGIN_SRC clojure
 
 ;; Various options:


### PR DESCRIPTION
I was confused about this and assumed I could also use `:body`. I thought this might help others too. LMK if I've misunderstood something here.