### PR TITLE
Avoid a NPE when the charset in a content type is empty

### DIFF
--- a/src/clj_http/util.clj
+++ b/src/clj_http/util.clj
@@ -144,7 +144,8 @@
         (or v1 v2)))))
 
 (defn- trim-quotes [s]
-  (clojure.string/replace s #"^\s*(\"(.*)\"|(.*?))\s*$" "$2$3"))
+  (when s
+    (clojure.string/replace s #"^\s*(\"(.*)\"|(.*?))\s*$" "$2$3")))
 
 (defn parse-content-type
   "Parse `s` as an RFC 2616 media type."

--- a/test/clj_http/test/util_test.clj
+++ b/test/clj_http/test/util_test.clj
@@ -46,7 +46,10 @@
      :content-type-params {:charset "utf-8"}}
     "text/html; charset=ISO-8859-4"
     {:content-type :text/html
-     :content-type-params {:charset "ISO-8859-4"}}))
+     :content-type-params {:charset "ISO-8859-4"}}
+    "text/html; charset="
+    {:content-type :text/html
+     :content-type-params {:charset nil}}))
 
 (deftest test-force-byte-array
   (testing "empty InputStream returns empty byte-array"


### PR DESCRIPTION
 Prevents `NullPointerException` thrown by `util/parse-content-type` when the charset specified in a content type is empty.

Example: `Content-Type: text/html;charset=`