### PR TITLE
Fix incorrect socket state when using SOCKS proxy

### DIFF
--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -41,10 +41,8 @@
   ([socket-factory ^SSLContext ssl-context]
    (let [^SSLContext ssl-context' (or ssl-context (SSLContexts/createDefault))]
      (proxy [SSLConnectionSocketFactory] [ssl-context']
-       (connectSocket [timeout socket host remoteAddress localAddress context]
-         (let [^SSLConnectionSocketFactory this this] ;; avoid reflection
-           (proxy-super connectSocket timeout (socket-factory) host remoteAddress
-                        localAddress context)))))))
+       (createSocket [context]
+         (socket-factory))))))
 
 (defn ^PlainConnectionSocketFactory PlainGenericSocketFactory
   "Given a Function that returns a new socket, create a

--- a/src/clj_http/conn_mgr.clj
+++ b/src/clj_http/conn_mgr.clj
@@ -37,10 +37,10 @@
   "Given a function that returns a new socket, create an
   SSLConnectionSocketFactory that will use that socket."
   ([socket-factory]
-   (SSLGenericSocketFactory socket-factory nil))
-  ([socket-factory ^SSLContext ssl-context]
+   (SSLGenericSocketFactory socket-factory nil nil))
+  ([socket-factory ^SSLContext ssl-context ^HostnameVerifier hostname-verifier]
    (let [^SSLContext ssl-context' (or ssl-context (SSLContexts/createDefault))]
-     (proxy [SSLConnectionSocketFactory] [ssl-context']
+     (proxy [SSLConnectionSocketFactory] [ssl-context' hostname-verifier]
        (createSocket [context]
          (socket-factory))))))
 
@@ -148,7 +148,9 @@
    (let [socket-factory #(socks-proxied-socket hostname port)
          registry (into-registry
                    {"http" (PlainGenericSocketFactory socket-factory)
-                    "https" (SSLGenericSocketFactory socket-factory (get-ssl-context config))})]
+                    "https" (SSLGenericSocketFactory socket-factory
+                             (get-ssl-context config)
+                             (get-hostname-verifier config))})]
      (PoolingHttpClientConnectionManager. registry))))
 
 (defn ^BasicHttpClientConnectionManager make-regular-conn-manager


### PR DESCRIPTION
The socket gets into an incorrect state across threads when the connection-manager is shared. New sockets should be created, same as plain HTTP.