### PR TITLE
Update the `project.clj` file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,12 @@
             :distribution :repo}
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.0.0"
-  :exclusions [org.clojure/clojure]
   :dependencies [[org.apache.httpcomponents/httpcore "4.4.16"]
                  [org.apache.httpcomponents/httpclient "4.5.14"]
                  [org.apache.httpcomponents/httpclient-cache "4.5.14"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.5"]
                  [org.apache.httpcomponents/httpmime "4.5.14"]
+                 [org.clojure/clojure "[1.8,1.13)" :scope "provided"]
                  [commons-codec "1.16.1"]
                  [commons-io "2.16.1"]
                  [slingshot "0.12.2"]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,6 @@
                  [org.apache.httpcomponents/httpclient-cache "4.5.14"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.5"]
                  [org.apache.httpcomponents/httpmime "4.5.14"]
-                 [org.clojure/clojure "[1.8,1.13)" :scope "provided"]
                  [commons-codec "1.16.1"]
                  [commons-io "2.16.1"]
                  [slingshot "0.12.2"]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                                   [com.cognitect/transit-clj "1.0.333"]
                                   [ring/ring-codec "1.2.0"]
                                   ;; other (testing) deps
-                                  [org.clojure/clojure "1.11.2"]
+                                  [org.clojure/clojure "1.12.1"]
                                   [org.clojure/tools.logging "1.3.0"]
                                   [ring/ring-jetty-adapter "1.12.1"]
                                   [ring/ring-devel "1.12.1"]
@@ -42,8 +42,9 @@
                              [lein-nvd "0.5.2"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
-  :aliases {"all" ["with-profile" "dev,1.8:dev,1.9:dev,1.10:dev"]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}}
+  :aliases {"all" ["with-profile" "dev,1.8:dev,1.9:dev,1.10:dev,1.11:dev"]}
   :plugins [[codox "0.6.4"]]
   :test-selectors {:default  #(not (:integration %))
                    :integration :integration

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,8 @@
                                   ;; logging
                                   [org.apache.logging.log4j/log4j-api "2.23.1"]
                                   [org.apache.logging.log4j/log4j-core "2.23.1"]
-                                  [org.apache.logging.log4j/log4j-1.2-api "2.23.1"]]
+                                  [org.apache.logging.log4j/log4j-1.2-api "2.23.1"]
+                                  [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1"]]
                    :plugins [[lein-ancient "0.7.0"]
                              [jonase/eastwood "0.2.5"]
                              [lein-kibit "0.1.5"]
@@ -46,6 +47,6 @@
              :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}}
   :aliases {"all" ["with-profile" "dev,1.8:dev,1.9:dev,1.10:dev,1.11:dev"]}
   :plugins [[codox "0.6.4"]]
-  :test-selectors {:default  #(not (:integration %))
+  :test-selectors {:default #(not (:integration %))
                    :integration :integration
                    :all (constantly true)})


### PR DESCRIPTION
Hello again!

My work on the tests for #654 revealed several issues with the Leiningen project descriptor, most notably the inability to run the tests (or even REPL) locally as specified in the `CONTRIBUTING.md` guide. This was due to a global exclusion of Clojure dependency.

After thinking for a while, I came up with a pretty standard solution for libraries — to use a "provided" dependency with an explicit range of supported Clojure versions. And of course, leave everything else intact.

The output of dependency trees for all test profiles looks like this after the changes.

<details>
<summary><code>lein with-profile -system,-user,+1.8:dev deps :tree</code></summary>
<pre>
Performing task 'deps' with profile(s): 'base,provided,dev,1.8'
Possibly confusing dependencies found:
[org.clojure/clojure "1.8.0"]
 overrides
[org.clojure/core.cache "1.1.234"] -> [org.clojure/data.priority-map "1.2.0"] -> [org.clojure/clojure "1.9.0"]
 and
[ring/ring-devel "1.12.1"] -> [ring/ring-core "1.12.1"] -> [org.clojure/clojure "1.9.0"]
 and
[ring/ring-jetty-adapter "1.12.1"] -> [org.ring-clojure/ring-jakarta-servlet "1.12.1"] -> [org.clojure/clojure "1.9.0"]
 and
[ring/ring-jetty-adapter "1.12.1"] -> [ring/ring-core "1.12.1"] -> [org.clojure/clojure "1.9.0"]
 and
[org.clojure/core.cache "1.1.234"] -> [org.clojure/clojure "1.9.0"]
 and
[ring/ring-devel "1.12.1"] -> [org.clojure/clojure "1.9.0"]
 and
[ring/ring-jetty-adapter "1.12.1"] -> [org.clojure/clojure "1.9.0"]
 and
[org.clojure/tools.logging "1.3.0"] -> [org.clojure/clojure "1.10.3"]
 and
[org.clojure/tools.reader "1.4.1"] -> [org.clojure/clojure "1.9.0"]

Consider using these exclusions:
[org.clojure/core.cache "1.1.234" :exclusions [org.clojure/clojure]]
[ring/ring-devel "1.12.1" :exclusions [org.clojure/clojure]]
[ring/ring-jetty-adapter "1.12.1" :exclusions [org.clojure/clojure]]
[org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/clojure]]
[org.clojure/tools.reader "1.4.1" :exclusions [org.clojure/clojure]]
</pre>
<pre>
 [cheshire "5.13.0" :scope "test"]
   [com.fasterxml.jackson.core/jackson-core "2.17.0" :scope "test"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [tigris "0.1.2" :scope "test"]
 [com.cognitect/transit-clj "1.0.333" :scope "test"]
   [com.cognitect/transit-java "1.0.371" :scope "test"]
     [javax.xml.bind/jaxb-api "2.4.0-b180830.0359" :scope "test"]
       [javax.activation/javax.activation-api "1.2.0" :scope "test"]
     [org.msgpack/msgpack "0.6.12" :scope "test"]
       [com.googlecode.json-simple/json-simple "1.1.1" :scope "test" :exclusions [[junit]]]
       [org.javassist/javassist "3.18.1-GA" :scope "test"]
 [commons-codec "1.16.1"]
 [commons-io "2.16.1"]
 [crouton "0.1.2" :scope "test" :exclusions [[org.jsoup/jsoup]]]
 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]
 [nrepl "1.0.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
   [org.apache.httpcomponents/httpcore-nio "4.4.15"]
 [org.apache.httpcomponents/httpclient-cache "4.5.14"]
 [org.apache.httpcomponents/httpclient "4.5.14"]
   [commons-logging "1.2"]
 [org.apache.httpcomponents/httpcore "4.4.16"]
 [org.apache.httpcomponents/httpmime "4.5.14"]
 [org.apache.logging.log4j/log4j-1.2-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-core "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1" :scope "test"]
   [org.slf4j/slf4j-api "2.0.9" :scope "test"]
 [org.clojure/clojure "1.8.0" :scope "test"]
 [org.clojure/core.cache "1.1.234" :scope "test"]
   [org.clojure/data.priority-map "1.2.0" :scope "test"]
 [org.clojure/tools.logging "1.3.0" :scope "test"]
 [org.clojure/tools.reader "1.4.1" :scope "test"]
 [org.jsoup/jsoup "1.17.2" :scope "test"]
 [org.nrepl/incomplete "0.1.0" :exclusions [[org.clojure/clojure]]]
 [potemkin "0.4.7"]
   [riddley "0.1.12"]
 [ring/ring-codec "1.2.0" :scope "test"]
 [ring/ring-devel "1.12.1" :scope "test"]
   [clj-stacktrace "0.2.8" :scope "test"]
   [hiccup "1.0.5" :scope "test"]
   [ns-tracker "0.4.0" :scope "test"]
     [org.clojure/java.classpath "0.3.0" :scope "test"]
     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 [ring/ring-jetty-adapter "1.12.1" :scope "test"]
   [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-api "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-common "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-common "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-server "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-security "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-webapp "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-xml "11.0.20" :scope "test"]
   [org.eclipse.jetty/jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api "5.0.2" :scope "test"]
     [org.eclipse.jetty/jetty-http "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-util "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-io "11.0.20" :scope "test"]
   [org.ring-clojure/ring-jakarta-servlet "1.12.1" :scope "test"]
   [ring/ring-core "1.12.1" :scope "test"]
     [crypto-equality "1.0.1" :scope "test"]
     [crypto-random "1.2.1" :scope "test"]
     [org.apache.commons/commons-fileupload2-core "2.0.0-M1" :scope "test"]
     [org.ring-clojure/ring-core-protocols "1.12.1" :scope "test"]
     [org.ring-clojure/ring-websocket-protocols "1.12.1" :scope "test"]
 [slingshot "0.12.2"]
</pre>
</details>

<details>
<summary><code>lein with-profile -system,-user,+1.9:dev deps :tree</code></summary>
<pre>
Performing task 'deps' with profile(s): 'base,provided,dev,1.9'
Possibly confusing dependencies found:
[org.clojure/clojure "1.9.0"]
 overrides
[org.clojure/tools.logging "1.3.0"] -> [org.clojure/clojure "1.10.3"]

Consider using these exclusions:
[org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/clojure]]

[org.clojure/clojure "1.9.0"] -> [org.clojure/spec.alpha "0.1.143"]
 overrides
[org.clojure/tools.logging "1.3.0"] -> [org.clojure/clojure "1.10.3"] -> [org.clojure/spec.alpha "0.2.194"]

Consider using these exclusions:
[org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/spec.alpha]]

[org.clojure/clojure "1.9.0"] -> [org.clojure/core.specs.alpha "0.1.24"]
 overrides
[org.clojure/tools.logging "1.3.0"] -> [org.clojure/clojure "1.10.3"] -> [org.clojure/core.specs.alpha "0.2.56"]

Consider using these exclusions:
[org.clojure/tools.logging "1.3.0" :exclusions [org.clojure/core.specs.alpha]]
</pre>
<pre>
 [cheshire "5.13.0" :scope "test"]
   [com.fasterxml.jackson.core/jackson-core "2.17.0" :scope "test"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [tigris "0.1.2" :scope "test"]
 [com.cognitect/transit-clj "1.0.333" :scope "test"]
   [com.cognitect/transit-java "1.0.371" :scope "test"]
     [javax.xml.bind/jaxb-api "2.4.0-b180830.0359" :scope "test"]
       [javax.activation/javax.activation-api "1.2.0" :scope "test"]
     [org.msgpack/msgpack "0.6.12" :scope "test"]
       [com.googlecode.json-simple/json-simple "1.1.1" :scope "test" :exclusions [[junit]]]
       [org.javassist/javassist "3.18.1-GA" :scope "test"]
 [commons-codec "1.16.1"]
 [commons-io "2.16.1"]
 [crouton "0.1.2" :scope "test" :exclusions [[org.jsoup/jsoup]]]
 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]
 [nrepl "1.0.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
   [org.apache.httpcomponents/httpcore-nio "4.4.15"]
 [org.apache.httpcomponents/httpclient-cache "4.5.14"]
 [org.apache.httpcomponents/httpclient "4.5.14"]
   [commons-logging "1.2"]
 [org.apache.httpcomponents/httpcore "4.4.16"]
 [org.apache.httpcomponents/httpmime "4.5.14"]
 [org.apache.logging.log4j/log4j-1.2-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-core "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1" :scope "test"]
   [org.slf4j/slf4j-api "2.0.9" :scope "test"]
 [org.clojure/clojure "1.9.0" :scope "test"]
   [org.clojure/core.specs.alpha "0.1.24" :scope "test"]
   [org.clojure/spec.alpha "0.1.143" :scope "test"]
 [org.clojure/core.cache "1.1.234" :scope "test"]
   [org.clojure/data.priority-map "1.2.0" :scope "test"]
 [org.clojure/tools.logging "1.3.0" :scope "test"]
 [org.clojure/tools.reader "1.4.1" :scope "test"]
 [org.jsoup/jsoup "1.17.2" :scope "test"]
 [org.nrepl/incomplete "0.1.0" :exclusions [[org.clojure/clojure]]]
 [potemkin "0.4.7"]
   [riddley "0.1.12"]
 [ring/ring-codec "1.2.0" :scope "test"]
 [ring/ring-devel "1.12.1" :scope "test"]
   [clj-stacktrace "0.2.8" :scope "test"]
   [hiccup "1.0.5" :scope "test"]
   [ns-tracker "0.4.0" :scope "test"]
     [org.clojure/java.classpath "0.3.0" :scope "test"]
     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 [ring/ring-jetty-adapter "1.12.1" :scope "test"]
   [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-api "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-common "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-common "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-server "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-security "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-webapp "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-xml "11.0.20" :scope "test"]
   [org.eclipse.jetty/jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api "5.0.2" :scope "test"]
     [org.eclipse.jetty/jetty-http "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-util "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-io "11.0.20" :scope "test"]
   [org.ring-clojure/ring-jakarta-servlet "1.12.1" :scope "test"]
   [ring/ring-core "1.12.1" :scope "test"]
     [crypto-equality "1.0.1" :scope "test"]
     [crypto-random "1.2.1" :scope "test"]
     [org.apache.commons/commons-fileupload2-core "2.0.0-M1" :scope "test"]
     [org.ring-clojure/ring-core-protocols "1.12.1" :scope "test"]
     [org.ring-clojure/ring-websocket-protocols "1.12.1" :scope "test"]
 [slingshot "0.12.2"]
</pre>
</details>

<details>
<summary><code>lein with-profile -system,-user,+1.10:dev deps :tree</code></summary>
<pre>
Performing task 'deps' with profile(s): 'base,provided,dev,1.10'
 [cheshire "5.13.0" :scope "test"]
   [com.fasterxml.jackson.core/jackson-core "2.17.0" :scope "test"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [tigris "0.1.2" :scope "test"]
 [com.cognitect/transit-clj "1.0.333" :scope "test"]
   [com.cognitect/transit-java "1.0.371" :scope "test"]
     [javax.xml.bind/jaxb-api "2.4.0-b180830.0359" :scope "test"]
       [javax.activation/javax.activation-api "1.2.0" :scope "test"]
     [org.msgpack/msgpack "0.6.12" :scope "test"]
       [com.googlecode.json-simple/json-simple "1.1.1" :scope "test" :exclusions [[junit]]]
       [org.javassist/javassist "3.18.1-GA" :scope "test"]
 [commons-codec "1.16.1"]
 [commons-io "2.16.1"]
 [crouton "0.1.2" :scope "test" :exclusions [[org.jsoup/jsoup]]]
 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]
 [nrepl "1.0.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
   [org.apache.httpcomponents/httpcore-nio "4.4.15"]
 [org.apache.httpcomponents/httpclient-cache "4.5.14"]
 [org.apache.httpcomponents/httpclient "4.5.14"]
   [commons-logging "1.2"]
 [org.apache.httpcomponents/httpcore "4.4.16"]
 [org.apache.httpcomponents/httpmime "4.5.14"]
 [org.apache.logging.log4j/log4j-1.2-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-core "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1" :scope "test"]
   [org.slf4j/slf4j-api "2.0.9" :scope "test"]
 [org.clojure/clojure "1.10.3" :scope "test"]
   [org.clojure/core.specs.alpha "0.2.56" :scope "test"]
   [org.clojure/spec.alpha "0.2.194" :scope "test"]
 [org.clojure/core.cache "1.1.234" :scope "test"]
   [org.clojure/data.priority-map "1.2.0" :scope "test"]
 [org.clojure/tools.logging "1.3.0" :scope "test"]
 [org.clojure/tools.reader "1.4.1" :scope "test"]
 [org.jsoup/jsoup "1.17.2" :scope "test"]
 [org.nrepl/incomplete "0.1.0" :exclusions [[org.clojure/clojure]]]
 [potemkin "0.4.7"]
   [riddley "0.1.12"]
 [ring/ring-codec "1.2.0" :scope "test"]
 [ring/ring-devel "1.12.1" :scope "test"]
   [clj-stacktrace "0.2.8" :scope "test"]
   [hiccup "1.0.5" :scope "test"]
   [ns-tracker "0.4.0" :scope "test"]
     [org.clojure/java.classpath "0.3.0" :scope "test"]
     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 [ring/ring-jetty-adapter "1.12.1" :scope "test"]
   [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-api "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-common "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-common "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-server "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-security "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-webapp "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-xml "11.0.20" :scope "test"]
   [org.eclipse.jetty/jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api "5.0.2" :scope "test"]
     [org.eclipse.jetty/jetty-http "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-util "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-io "11.0.20" :scope "test"]
   [org.ring-clojure/ring-jakarta-servlet "1.12.1" :scope "test"]
   [ring/ring-core "1.12.1" :scope "test"]
     [crypto-equality "1.0.1" :scope "test"]
     [crypto-random "1.2.1" :scope "test"]
     [org.apache.commons/commons-fileupload2-core "2.0.0-M1" :scope "test"]
     [org.ring-clojure/ring-core-protocols "1.12.1" :scope "test"]
     [org.ring-clojure/ring-websocket-protocols "1.12.1" :scope "test"]
 [slingshot "0.12.2"]
</pre>
</details>

<details>
<summary><code>lein with-profile -system,-user,+1.11:dev deps :tree</code></summary>
<pre>
Performing task 'deps' with profile(s): 'base,provided,dev,1.11'
 [cheshire "5.13.0" :scope "test"]
   [com.fasterxml.jackson.core/jackson-core "2.17.0" :scope "test"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [tigris "0.1.2" :scope "test"]
 [com.cognitect/transit-clj "1.0.333" :scope "test"]
   [com.cognitect/transit-java "1.0.371" :scope "test"]
     [javax.xml.bind/jaxb-api "2.4.0-b180830.0359" :scope "test"]
       [javax.activation/javax.activation-api "1.2.0" :scope "test"]
     [org.msgpack/msgpack "0.6.12" :scope "test"]
       [com.googlecode.json-simple/json-simple "1.1.1" :scope "test" :exclusions [[junit]]]
       [org.javassist/javassist "3.18.1-GA" :scope "test"]
 [commons-codec "1.16.1"]
 [commons-io "2.16.1"]
 [crouton "0.1.2" :scope "test" :exclusions [[org.jsoup/jsoup]]]
 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]
 [nrepl "1.0.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
   [org.apache.httpcomponents/httpcore-nio "4.4.15"]
 [org.apache.httpcomponents/httpclient-cache "4.5.14"]
 [org.apache.httpcomponents/httpclient "4.5.14"]
   [commons-logging "1.2"]
 [org.apache.httpcomponents/httpcore "4.4.16"]
 [org.apache.httpcomponents/httpmime "4.5.14"]
 [org.apache.logging.log4j/log4j-1.2-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-core "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1" :scope "test"]
   [org.slf4j/slf4j-api "2.0.9" :scope "test"]
 [org.clojure/clojure "1.11.4" :scope "test"]
   [org.clojure/core.specs.alpha "0.2.62" :scope "test"]
   [org.clojure/spec.alpha "0.3.218" :scope "test"]
 [org.clojure/core.cache "1.1.234" :scope "test"]
   [org.clojure/data.priority-map "1.2.0" :scope "test"]
 [org.clojure/tools.logging "1.3.0" :scope "test"]
 [org.clojure/tools.reader "1.4.1" :scope "test"]
 [org.jsoup/jsoup "1.17.2" :scope "test"]
 [org.nrepl/incomplete "0.1.0" :exclusions [[org.clojure/clojure]]]
 [potemkin "0.4.7"]
   [riddley "0.1.12"]
 [ring/ring-codec "1.2.0" :scope "test"]
 [ring/ring-devel "1.12.1" :scope "test"]
   [clj-stacktrace "0.2.8" :scope "test"]
   [hiccup "1.0.5" :scope "test"]
   [ns-tracker "0.4.0" :scope "test"]
     [org.clojure/java.classpath "0.3.0" :scope "test"]
     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 [ring/ring-jetty-adapter "1.12.1" :scope "test"]
   [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-api "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-common "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-common "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-server "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-security "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-webapp "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-xml "11.0.20" :scope "test"]
   [org.eclipse.jetty/jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api "5.0.2" :scope "test"]
     [org.eclipse.jetty/jetty-http "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-util "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-io "11.0.20" :scope "test"]
   [org.ring-clojure/ring-jakarta-servlet "1.12.1" :scope "test"]
   [ring/ring-core "1.12.1" :scope "test"]
     [crypto-equality "1.0.1" :scope "test"]
     [crypto-random "1.2.1" :scope "test"]
     [org.apache.commons/commons-fileupload2-core "2.0.0-M1" :scope "test"]
     [org.ring-clojure/ring-core-protocols "1.12.1" :scope "test"]
     [org.ring-clojure/ring-websocket-protocols "1.12.1" :scope "test"]
 [slingshot "0.12.2"]
</pre>
</details>

<details>
<summary><code>lein with-profile -system,-user,+dev deps :tree</code> (for the latest Clojure <code>1.12.1</code> which is now covered a well)</summary>
<pre>
 [cheshire "5.13.0" :scope "test"]
   [com.fasterxml.jackson.core/jackson-core "2.17.0" :scope "test"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.17.0" :scope "test" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
   [tigris "0.1.2" :scope "test"]
 [com.cognitect/transit-clj "1.0.333" :scope "test"]
   [com.cognitect/transit-java "1.0.371" :scope "test"]
     [javax.xml.bind/jaxb-api "2.4.0-b180830.0359" :scope "test"]
       [javax.activation/javax.activation-api "1.2.0" :scope "test"]
     [org.msgpack/msgpack "0.6.12" :scope "test"]
       [com.googlecode.json-simple/json-simple "1.1.1" :scope "test" :exclusions [[junit]]]
       [org.javassist/javassist "3.18.1-GA" :scope "test"]
 [commons-codec "1.16.1"]
 [commons-io "2.16.1"]
 [crouton "0.1.2" :scope "test" :exclusions [[org.jsoup/jsoup]]]
 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]
 [nrepl "1.0.0" :exclusions [[org.clojure/clojure]]]
 [org.apache.httpcomponents/httpasyncclient "4.1.5"]
   [org.apache.httpcomponents/httpcore-nio "4.4.15"]
 [org.apache.httpcomponents/httpclient-cache "4.5.14"]
 [org.apache.httpcomponents/httpclient "4.5.14"]
   [commons-logging "1.2"]
 [org.apache.httpcomponents/httpcore "4.4.16"]
 [org.apache.httpcomponents/httpmime "4.5.14"]
 [org.apache.logging.log4j/log4j-1.2-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-api "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-core "2.23.1" :scope "test"]
 [org.apache.logging.log4j/log4j-slf4j2-impl "2.23.1" :scope "test"]
   [org.slf4j/slf4j-api "2.0.9" :scope "test"]
 [org.clojure/clojure "1.12.1" :scope "test"]
   [org.clojure/core.specs.alpha "0.4.74" :scope "test"]
   [org.clojure/spec.alpha "0.5.238" :scope "test"]
 [org.clojure/core.cache "1.1.234" :scope "test"]
   [org.clojure/data.priority-map "1.2.0" :scope "test"]
 [org.clojure/tools.logging "1.3.0" :scope "test"]
 [org.clojure/tools.reader "1.4.1" :scope "test"]
 [org.jsoup/jsoup "1.17.2" :scope "test"]
 [org.nrepl/incomplete "0.1.0" :exclusions [[org.clojure/clojure]]]
 [potemkin "0.4.7"]
   [riddley "0.1.12"]
 [ring/ring-codec "1.2.0" :scope "test"]
 [ring/ring-devel "1.12.1" :scope "test"]
   [clj-stacktrace "0.2.8" :scope "test"]
   [hiccup "1.0.5" :scope "test"]
   [ns-tracker "0.4.0" :scope "test"]
     [org.clojure/java.classpath "0.3.0" :scope "test"]
     [org.clojure/tools.namespace "0.2.11" :scope "test"]
 [ring/ring-jetty-adapter "1.12.1" :scope "test"]
   [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-api "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-jetty-common "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-common "11.0.20" :scope "test"]
     [org.eclipse.jetty.websocket/websocket-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty.websocket/websocket-core-server "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-servlet "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-security "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-webapp "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-xml "11.0.20" :scope "test"]
   [org.eclipse.jetty/jetty-server "11.0.20" :scope "test"]
     [org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api "5.0.2" :scope "test"]
     [org.eclipse.jetty/jetty-http "11.0.20" :scope "test"]
       [org.eclipse.jetty/jetty-util "11.0.20" :scope "test"]
     [org.eclipse.jetty/jetty-io "11.0.20" :scope "test"]
   [org.ring-clojure/ring-jakarta-servlet "1.12.1" :scope "test"]
   [ring/ring-core "1.12.1" :scope "test"]
     [crypto-equality "1.0.1" :scope "test"]
     [crypto-random "1.2.1" :scope "test"]
     [org.apache.commons/commons-fileupload2-core "2.0.0-M1" :scope "test"]
     [org.ring-clojure/ring-core-protocols "1.12.1" :scope "test"]
     [org.ring-clojure/ring-websocket-protocols "1.12.1" :scope "test"]
 [slingshot "0.12.2"]
</pre>
</details>

From all this output it is clear that:
a. The correct version of Clojure is used every time.
b. There are already some Clojure version conflicts within `1.8` (major) and `1.9` (minor) in the development environment. (Which of course can be resolved by separate dev profiles for those versions, but hey, the tests pass, so everything should work without issues.)

OTOH, having Clojure in `:exclusions` results in information about its versions across all dependencies wiped away. And, in my experience, it's better to have all dependency information explicitly. It usually helps later when making decisions or analyzing issues.

Most importantly, now anyone can run the full test suite using the `lein all test :all` without any obstacles. 😉 

@dakrone Please, tell me if I'm missing something important here. Probably not, but maybe I'm out of touch with `lein`.

Have a good one!

Cheers,
Mark