### PR TITLE
Use clj-commons.slingshot

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ["14", "17", "21"]
-        clojure: ["1.8", "1.9", "1.10", "1.11"]
+        java: ["14", "17", "21", "25"]
+        clojure: ["1.8", "1.9", "1.10", "1.11", "1.12"]
 
     name: Java ${{ matrix.java }} Clojure ${{ matrix.clojure }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v6
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-lein-
 
     - name: Setup java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ matrix.java }}
 

--- a/README.org
+++ b/README.org
@@ -852,7 +852,7 @@ files or =KeyStore= instances.
 
 The client will throw exceptions on, well, exceptional status codes, meaning all
 HTTP responses other than =#{200 201 202 203 204 205 206 207 300 301 302 303 304
-307}=. clj-http will throw a [[http://github.com/scgilardi/slingshot][Slingshot]] Stone that can be caught by a regular
+307}=. clj-http will throw a [[http://github.com/clj-commons/slingshot][Slingshot]] Stone that can be caught by a regular
 =(catch Exception e ...)= or in Slingshot's =try+= block:
 
 #+BEGIN_SRC clojure

--- a/project.clj
+++ b/project.clj
@@ -11,9 +11,9 @@
                  [org.apache.httpcomponents/httpclient-cache "4.5.14"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.5"]
                  [org.apache.httpcomponents/httpmime "4.5.14"]
+                 [org.clj-commons/slingshot "0.13.0"]
                  [commons-codec "1.16.1"]
                  [commons-io "2.16.1"]
-                 [slingshot "0.12.2"]
                  [potemkin "0.4.7"]]
   :resource-paths ["resources"]
   :profiles {:dev {:dependencies [;; optional deps

--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -1,7 +1,8 @@
 (ns clj-http.client
   "Batteries-included HTTP client."
   (:refer-clojure :exclude [get update])
-  (:require [clj-http.conn-mgr :as conn]
+  (:require [clj-commons.slingshot :refer [throw+]]
+            [clj-http.conn-mgr :as conn]
             [clj-http.cookies :refer [wrap-cookies]]
             [clj-http.core :as core]
             [clj-http.headers :refer [wrap-header-map]]
@@ -11,9 +12,8 @@
             [clojure.stacktrace :refer [root-cause]]
             [clojure.string :as str]
             [clojure.walk :refer [keywordize-keys prewalk]]
-            [clojure.xml :as xml]
-            [slingshot.slingshot :refer [throw+]])
-  (:import [java.io BufferedReader ByteArrayInputStream ByteArrayOutputStream EOFException File InputStream]
+            [clojure.xml :as xml])
+  (:import [java.io BufferedReader ByteArrayOutputStream EOFException File InputStream]
            [java.net UnknownHostException URL]
            [org.apache.http.entity BufferedHttpEntity ByteArrayEntity FileEntity InputStreamEntity StringEntity]
            [javax.xml.parsers SAXParser SAXParserFactory]
@@ -479,8 +479,8 @@
   (..
    (doto
     (SAXParserFactory/newInstance)
-     (.setFeature
-      "http://apache.org/xml/features/nonvalidating/load-external-dtd" false))
+    (.setFeature
+     "http://apache.org/xml/features/nonvalidating/load-external-dtd" false))
    (newSAXParser)))
 
 (defn- non-validating [s ^DefaultHandler ch]

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1,16 +1,16 @@
 (ns clj-http.test.client-test
   (:require [cheshire.core :as json]
+            [clj-commons.slingshot :refer [try+]]
             [clj-http.client :as client]
             [clj-http.conn-mgr :as conn]
             [clj-http.test.core-test :refer [run-server]]
             [clj-http.util :as util]
             [clojure.java.io :as io :refer [resource]]
             [clojure.string :as str]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is testing]]
             [cognitect.transit :as transit]
             [ring.middleware.nested-params :refer [parse-nested-keys]]
-            [ring.util.codec :refer [form-decode-str]]
-            [slingshot.slingshot :refer [try+]])
+            [ring.util.codec :refer [form-decode-str]])
   (:import java.io.ByteArrayInputStream
            java.io.PipedInputStream
            java.io.PipedOutputStream
@@ -507,7 +507,7 @@
   (doseq [method [:put :post :delete]
           status [301 302 307 308]]
     (let [client (fn [req] {:status status :body (:body req)
-                           :headers {"location" "http://example.com/bat"}})
+                            :headers {"location" "http://example.com/bat"}})
           r-client (client/wrap-redirects client)
           resp (r-client {:body "ok" :url "http://example.com"
                           :request-method method})]
@@ -1380,7 +1380,7 @@
                 (fn [req] {:body nil})) {:decode-body-headers true})
         resp4 ((client/wrap-additional-header-parsing
                 (fn [req] {:headers {"content-type" "application/pdf"}
-                          :body (.getBytes text)}))
+                           :body (.getBytes text)}))
                {:decode-body-headers true})]
     (is (= {"content-type" "text/html; charset=Shift_JIS"
             "content-style-type" "text/css"


### PR DESCRIPTION
Sadly, the maintainer of the original slingshot has passed away.

The slingshot library has been adopted into the clj-commons repository and will be maintained under a different set of coordinates going forward.

fixes #658

-=david=-