### PR TITLE
ci: fix the broken build matrix (setup-java distribution, missing lein, reflection gate)

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -31,6 +31,11 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
 
+    - name: Setup Leiningen
+      uses: DeLaGuardo/setup-clojure@13.4
+      with:
+        lein: 2.11.2
+
     - name: Install dependencies
       run: lein deps
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Setup java
       uses: actions/setup-java@v5
       with:
+        distribution: zulu
         java-version: ${{ matrix.java }}
 
     - name: Install dependencies

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -5,6 +5,7 @@ on:
     branches: [ 3.x ]
   pull_request:
     branches: [ 3.x ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -36,4 +37,4 @@ jobs:
       run: lein with-profile dev,${{matrix.clojure}} test :all
 
     - name: Check Reflection Warnings
-      run:  '! lein with-profile dev,${{matrix.clojure}} check 2>&1 | egrep "Reflection warning|Performance warning"'
+      run:  '! lein with-profile dev,${{matrix.clojure}} check 2>&1 | egrep "Reflection warning|Performance warning" | egrep "clj_http/"'


### PR DESCRIPTION
The CI badge has been red for months. The cause is workflow rot, not the code (the test suite passes locally and on a fixed matrix). Three independent breakages:

1. **`setup-java@v5` had no `distribution`.** v2+ requires it, so every cell failed immediately at the *Setup java* step with `Input required and not supplied: distribution`. Set `distribution: zulu` (covers the whole 14/17/21/25 matrix).

2. **`lein` was assumed pre-installed.** Current `ubuntu-latest` no longer ships Leiningen, so every `lein` step failed with exit code 127 (command not found). Added a `setup-clojure` step that installs a pinned Leiningen.

3. **The reflection-warning gate matched dependency warnings.** It greps the full output of `lein check`, which includes warnings from compiling deps. The optional dev dep `crouton` emits one (`crouton/html.clj`), so the gate failed even though clj-http's own source is clean. Scoped the grep to `clj_http/`.

Also added a `workflow_dispatch` trigger so the matrix can be re-run manually.

Full 4×5 matrix green on my fork after these fixes - https://github.com/jsavyasachi/clj-http/actions/runs/27911790757
