### PR TITLE
fix(client): encode query-param spaces as %20 instead of + (#626)

### DIFF
--- a/src/clj_http/client.clj
+++ b/src/clj_http/client.clj
@@ -833,6 +833,14 @@
   (let [encoding (detect-charset content-type)]
     (generate-query-string-with-encoding params encoding multi-param-style)))
 
+(defn- uri-encode-query-spaces
+  "URLEncoder encodes a space as `+`, which is correct for an
+  x-www-form-urlencoded body but not for the query component of a URI, where a
+  space should be `%20` (RFC 3986). Every literal `+` is already percent-encoded
+  as `%2B` by this point, so each remaining `+` is an encoded space."
+  [query-string]
+  (str/replace query-string "+" "%20"))
+
 (defn- query-params-request
   [{:keys [query-params content-type multi-param-style]
     :or {content-type :x-www-form-urlencoded}
@@ -844,10 +852,11 @@
                      (if-not (empty? old-query-string)
                        (str old-query-string "&" new-query-string)
                        new-query-string))
-                   (generate-query-string
-                    query-params
-                    (content-type-value content-type)
-                    multi-param-style)))
+                   (uri-encode-query-spaces
+                    (generate-query-string
+                     query-params
+                     (content-type-value content-type)
+                     multi-param-style))))
     req))
 
 (defn wrap-query-params

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -962,7 +962,15 @@
   (is-applied client/wrap-query-params
               {:query-string "foo=1"
                :query-params {"foo" ["2" "3"]}}
-              {:query-string "foo=1&foo=2&foo=3"}))
+              {:query-string "foo=1&foo=2&foo=3"})
+  (testing "spaces in query params encode as %20, not + (#626)"
+    (is-applied client/wrap-query-params
+                {:query-params {"q" "a b c"}}
+                {:query-string "q=a%20b%20c"})
+    (testing "a literal + in a value stays percent-encoded as %2B"
+      (is-applied client/wrap-query-params
+                  {:query-params {"q" "a+b"}}
+                  {:query-string "q=a%2Bb"}))))
 
 (deftest apply-on-query-params-async
   (is-applied-async client/wrap-query-params
@@ -1123,6 +1131,12 @@
       (is (= "param1=value1&param2=value2" (:body resp)))
       (is (= "application/x-www-form-urlencoded" (:content-type resp)))
       (is (not (contains? resp :form-params)))))
+
+  (testing "spaces in form-param bodies stay + (x-www-form-urlencoded), unlike query params (#626)"
+    (let [param-client (client/wrap-form-params identity)
+          resp (param-client {:request-method :post
+                              :form-params (sorted-map :q "a b c")})]
+      (is (= "q=a+b+c" (:body resp)))))
 
   (testing "With json form params"
     (let [param-client (client/wrap-form-params identity)


### PR DESCRIPTION
Fixes #626.

Spaces in `:query-params` are encoded as `+` rather than `%20`. `+` is correct for an `application/x-www-form-urlencoded` body, but in the query component of a URI a space should be `%20` (RFC 3986); `+` there is only conventionally - not standardly - read as a space.

`generate-query-string` is shared by both the form-params (body) and query-params (URI) paths, so the fix is applied only on the query-params path. By that point every literal `+` is already percent-encoded as `%2B`, so each remaining `+` is an encoded space and is rewritten to `%20`. Form-param bodies are left unchanged.

This also matches the convention already used by `url-encode-illegal-characters` for raw URL query strings ("Minimizes ambiguity by encoding space to %20").

Tests: query params with spaces -> `%20`; a literal `+` value stays `%2B`; form-param bodies still use `+`.
