### PR TITLE
fix(multipart): honor :name as filename for File parts without :mime-type

### DIFF
--- a/src/clj_http/multipart.clj
+++ b/src/clj_http/multipart.clj
@@ -45,6 +45,9 @@
     (and mime-type content)
     (FileBody. content (ContentType/create mime-type))
 
+    (and name content)
+    (FileBody. content ContentType/DEFAULT_BINARY name)
+
     content
     (FileBody. content)
 

--- a/test/clj_http/test/multipart_test.clj
+++ b/test/clj_http/test/multipart_test.clj
@@ -134,6 +134,14 @@
         (is (instance? FileBody body))
         (is (= test-file (.getFile body)))))
 
+    (testing "can create FileBody with content and name but no mime-type"
+      (let [test-file (File. "testfile")
+            body (make-multipart-body {:content test-file
+                                       :name    "testname"})]
+        (is (instance? FileBody body))
+        (is (= test-file (.getFile body)))
+        (is (= "testname" (.getFilename body)))))
+
     (testing "can create FileBody with content and mime-type"
       (let [test-file (File. "testfile")
             body (make-multipart-body {:content   test-file


### PR DESCRIPTION
Fixes #634.

## Problem

A `File` multipart part supplied with `:name` but no `:mime-type` falls through to the bare `(FileBody. content)` branch in `make-multipart-body`. Apache's single-arg `FileBody` constructor uses the file's own on-disk name, so the supplied `:name` is silently dropped. This is exactly the surprise reported in #634, and it makes the README's `{:name "file" :content (clojure.java.io/file "pic.jpg")}` example send `pic.jpg` rather than the documented `:name`.

`ByteArray` and `InputStream` parts already honor `:name` as the filename in the no-mime-type case; `File` parts were the inconsistent one.

## Fix

Add a `(and name content)` branch that passes the name through with `ContentType/DEFAULT_BINARY` - the same content type the single-arg `FileBody` constructor applies internally - so **only the filename behavior changes**, not the content type.

## Behavior change (please review)

For a `File` part with `:name` and no `:mime-type`, the multipart filename now reflects the supplied `:name` instead of the file's on-disk name. This aligns `File` with the other body types and with the documented example, but it is a visible change for anyone who relied on the old fall-through. Flagging explicitly.

## Tests

Added a `multipart-test` case asserting `:name` (distinct from the file's own name) wins as `.getFilename`.